### PR TITLE
Upgrade to lts-5.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,14 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-4.0
+resolver: lts-5.0
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-  - parseerror-eq-0.1.0.1
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
I updated the stack.yml file to the lts-5.0. The library `parseerror-eq-0.1.0.1` is included in this lts, so I think we can remove it from the extra-dependency list in the stack.yml file.