### PR TITLE
Add Text version of parsefile along with String version

### DIFF
--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -53,7 +53,6 @@ executable dotenv
                        , optparse-applicative >=0.11 && < 0.13
                        , megaparsec >= 4.2.0 && < 4.5.0
                        , process
-                       , text
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -65,7 +64,6 @@ library
   build-depends:         base >=4.5 && <5.0
                        , base-compat >= 0.4
                        , megaparsec >= 4.2.0 && < 4.5.0
-                       , text
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -84,7 +82,6 @@ test-suite dotenv-test
   build-depends:       base >=4.5 && <5.0
                      , base-compat >= 0.4
                      , megaparsec >= 4.2.0 && < 4.5.0
-                     , text
                      , hspec
 
   default-language:    Haskell2010

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -53,6 +53,7 @@ executable dotenv
                        , optparse-applicative >=0.11 && < 0.13
                        , megaparsec >= 4.2.0 && < 4.5.0
                        , process
+                       , text
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -64,6 +65,7 @@ library
   build-depends:         base >=4.5 && <5.0
                        , base-compat >= 0.4
                        , megaparsec >= 4.2.0 && < 4.5.0
+                       , text
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -75,6 +77,7 @@ test-suite dotenv-test
   hs-source-dirs: spec, src
   main-is: Spec.hs
   other-modules:         Configuration.DotenvSpec
+                       , Configuration.Dotenv.TextSpec
                        , Configuration.Dotenv.ParseSpec
                        , Configuration.Dotenv
                        , Configuration.Dotenv.Parse
@@ -83,6 +86,7 @@ test-suite dotenv-test
                      , base-compat >= 0.4
                      , megaparsec >= 4.2.0 && < 4.5.0
                      , hspec
+                     , text
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/spec/Configuration/Dotenv/ParseSpec.hs
+++ b/spec/Configuration/Dotenv/ParseSpec.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Configuration.Dotenv.ParseSpec (main, spec) where
 
@@ -8,8 +7,6 @@ import Configuration.Dotenv.Parse (configParser)
 import Test.Hspec (it, describe, shouldBe, Spec, hspec)
 
 import Text.Megaparsec (ParseError, parse)
-
-import qualified Data.Text as T
 
 main :: IO ()
 main = hspec spec
@@ -89,5 +86,5 @@ isLeft :: Either a b -> Bool
 isLeft ( Left _ ) = True
 isLeft _          = False
 
-parseConfig :: T.Text -> Either ParseError [(T.Text, T.Text)]
+parseConfig :: String -> Either ParseError [(String, String)]
 parseConfig = parse configParser "(unknown)"

--- a/spec/Configuration/Dotenv/TextSpec.hs
+++ b/spec/Configuration/Dotenv/TextSpec.hs
@@ -1,0 +1,29 @@
+module Configuration.Dotenv.TextSpec (main, spec) where
+
+import Configuration.Dotenv.Text (parseFile)
+
+import Test.Hspec
+
+import System.Environment.Compat (lookupEnv, setEnv, unsetEnv)
+import Control.Monad (liftM)
+import qualified Data.Text as T
+
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "parseFile" $ after_ (unsetEnv "DOTENV") $ do
+    it "returns variables from a file without changing the environment" $ do
+      lookupEnv "DOTENV" `shouldReturn` Nothing
+
+      liftM head (parseFile "spec/fixtures/.dotenv") `shouldReturn`
+        (T.pack "DOTENV", T.pack "true")
+
+      lookupEnv "DOTENV" `shouldReturn` Nothing
+
+    it "recognizes unicode characters" $
+      liftM (!! 1) (parseFile "spec/fixtures/.dotenv") `shouldReturn`
+        (T.pack "UNICODE_TEST", T.pack "Manabí")

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Configuration.DotenvSpec (main, spec) where
 
 import Configuration.Dotenv (load, loadFile, parseFile)
@@ -9,7 +7,7 @@ import Test.Hspec
 import System.Environment.Compat (lookupEnv, setEnv, unsetEnv)
 import Control.Monad (liftM)
 
-{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
+{-# ANN module "HLint: ignore Reduce duplication" #-}
 
 main :: IO ()
 main = hspec spec
@@ -64,7 +62,7 @@ spec = do
     it "returns variables from a file without changing the environment" $ do
       lookupEnv "DOTENV" `shouldReturn` Nothing
 
-      liftM head (parseFile "spec/fixtures/.dotenv") `shouldReturn`
+      (liftM head $ parseFile "spec/fixtures/.dotenv") `shouldReturn`
         ("DOTENV", "true")
 
       lookupEnv "DOTENV" `shouldReturn` Nothing

--- a/src/Configuration/Dotenv/Parse.hs
+++ b/src/Configuration/Dotenv/Parse.hs
@@ -35,10 +35,10 @@ configParser = catMaybes <$> many envLine <* eof
 
 
 envLine :: Parser (Maybe (T.Text, T.Text))
-envLine = (comment <|> blankLine) *> return Nothing <|> Just <$> optionLine
+envLine = liftM T.pack (comment <|> blankLine) *> return Nothing <|> Just <$> optionLine
 
-blankLine :: Parser T.Text
-blankLine = liftM T.pack (many verticalSpace <* newline) <?> "blank line"
+blankLine :: Parser String
+blankLine = many verticalSpace <* newline <?> "blank line"
 
 optionLine :: Parser (T.Text, T.Text)
 optionLine = liftM2 (,)
@@ -66,7 +66,7 @@ quotedValue = (quotedWith '\'' <|> quotedWith '\"')
 
 unquotedValue :: Parser T.Text
 unquotedValue =
-  liftM T.pack (manyTill anyChar (liftM T.unpack comment <|> many verticalSpace <* endOfLineOrInput))
+  liftM T.pack (manyTill anyChar (comment <|> many verticalSpace <* endOfLineOrInput))
 
 -- | Based on a commented-string parser in:
 -- http://hub.darcs.net/navilan/XMonadTasks/raw/Data/Config/Lexer.hs
@@ -76,9 +76,9 @@ quotedWith c = liftM T.pack (char c *> many chr <* (char c <?> "closing quote ch
   where chr = esc <|> noneOf [c]
         esc = escape *> char c <?> "escape character"
 
-comment :: Parser T.Text
-comment = liftM T.pack (try (many verticalSpace *> char '#')
-          *> manyTill anyChar endOfLineOrInput)
+comment :: Parser String
+comment = try (many verticalSpace *> char '#')
+          *> manyTill anyChar endOfLineOrInput
           <?> "comment"
 
 endOfLineOrInput :: Parser ()

--- a/src/Configuration/Dotenv/Parse.hs
+++ b/src/Configuration/Dotenv/Parse.hs
@@ -15,7 +15,7 @@
 module Configuration.Dotenv.Parse (configParser) where
 
 import Text.Megaparsec ((<?>), anyChar, char, eof, manyTill, try)
-import Text.Megaparsec.Text (Parser)
+import Text.Megaparsec.String (Parser)
 import Text.Megaparsec.Char
   (digitChar, letterChar, newline, noneOf, oneOf)
 
@@ -23,55 +23,53 @@ import Control.Applicative
 import Prelude
 
 import Data.Maybe (catMaybes)
-import Control.Monad (liftM, liftM2)
-
-import qualified Data.Text as T
+import Control.Monad (liftM2)
 
 -- | Returns a parser for a Dotenv configuration file.  Accepts key
 -- and value arguments separated by "=".  Comments are allowed on
 -- lines by themselves and on blank lines.
-configParser :: Parser [(T.Text, T.Text)]
+configParser :: Parser [(String, String)]
 configParser = catMaybes <$> many envLine <* eof
 
 
-envLine :: Parser (Maybe (T.Text, T.Text))
-envLine = liftM T.pack (comment <|> blankLine) *> return Nothing <|> Just <$> optionLine
+envLine :: Parser (Maybe (String, String))
+envLine = (comment <|> blankLine) *> return Nothing <|> Just <$> optionLine
 
 blankLine :: Parser String
 blankLine = many verticalSpace <* newline <?> "blank line"
 
-optionLine :: Parser (T.Text, T.Text)
+optionLine :: Parser (String, String)
 optionLine = liftM2 (,)
   (many verticalSpace *> variableName <* variableValueSeparator)
   value
 
 -- | Variables must start with a letter or underscore, and may contain
 -- letters, digits or '_' character after the first character.
-variableName :: Parser T.Text
-variableName = liftM T.pack (liftM2 (:) (letterChar <|> char '_')
+variableName :: Parser String
+variableName = liftM2 (:) (letterChar <|> char '_')
   (many (letterChar <|> char '_' <|> digitChar <?>
          unwords [ "valid non-leading shell variable character (alphanumeric,"
-                 , "digit or underscore)" ])))
+                 , "digit or underscore)" ]))
 
   <?> unwords [ "shell variable name (letter or underscore followed"
               , "by alphanumeric characters or underscores)" ]
 
-value :: Parser T.Text
+value :: Parser String
 value = quotedValue <|> unquotedValue <?> "variable value"
 
-quotedValue :: Parser T.Text
+quotedValue :: Parser String
 quotedValue = (quotedWith '\'' <|> quotedWith '\"')
   <* (comment *> return () <|> many verticalSpace *> endOfLineOrInput)
   <?> "variable value surrounded with single or double quotes"
 
-unquotedValue :: Parser T.Text
+unquotedValue :: Parser String
 unquotedValue =
-  liftM T.pack (manyTill anyChar (comment <|> many verticalSpace <* endOfLineOrInput))
+  manyTill anyChar (comment <|> many verticalSpace <* endOfLineOrInput)
 
 -- | Based on a commented-string parser in:
 -- http://hub.darcs.net/navilan/XMonadTasks/raw/Data/Config/Lexer.hs
-quotedWith :: Char -> Parser T.Text
-quotedWith c = liftM T.pack (char c *> many chr <* (char c <?> "closing quote character"))
+quotedWith :: Char -> Parser String
+quotedWith c = char c *> many chr <* (char c <?> "closing quote character")
 
   where chr = esc <|> noneOf [c]
         esc = escape *> char c <?> "escape character"

--- a/src/Configuration/Dotenv/Text.hs
+++ b/src/Configuration/Dotenv/Text.hs
@@ -1,0 +1,13 @@
+module Configuration.Dotenv.Text (parseFile) where
+
+import qualified Configuration.Dotenv
+
+import qualified Data.Text as T
+import Control.Arrow ((***))
+
+-- | Parses the given dotenv file and returns values /without/ adding them to
+-- the environment.
+parseFile ::
+  FilePath -- ^ A file containing options to read
+  -> IO [(T.Text, T.Text)] -- ^ Variables contained in the file
+parseFile f = map (T.pack *** T.pack) `fmap` Configuration.Dotenv.parseFile f


### PR DESCRIPTION
Functions in `System.Environment`, `System.Process` etc. returns or takes environment variables as `String`, not `Text`.
In many cases users will merge them with ones from dotenv, so it'll be better to leave interfaces in plain String for their convenience.