### PR TITLE
Remove extra dependencies from stack.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,6 @@ matrix:
 
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2"
-    addons: {apt: {packages: [ghc-7.10.2], sources: [hvr-ghc]}}
-
   - env: BUILD=stack ARGS="--resolver lts-5"
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
@@ -59,10 +55,6 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Build on OS X in addition to Linux
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2 osx"
-    os: osx
-
   - env: BUILD=stack ARGS="--resolver lts-5"
     compiler: ": #stack 7.10.3 osx"
     os: osx

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,9 @@
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.0
+resolver: lts-5.8
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
-
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-  - fail-4.9.0.0
-  - megaparsec-4.4.0
-  - semigroups-0.18.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
@jsl This is what I had in mind regarding issue #19 (and https://github.com/stackbuilders/dotenv-hs/issues/19#issuecomment-198982228 in particular).

(Not a big deal, but it takes around eight minutes less to finish all build jobs.)