### PR TITLE
Args

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,6 +19,7 @@ data Options = Options
   { files    :: [String]
   , overload :: Bool
   , program  :: String
+  , args     :: [String]
   } deriving (Show)
 
 main :: IO ()
@@ -43,8 +44,11 @@ config = Options
 
      <*> argument str (metavar "PROGRAM")
 
+     <*> many (argument str (metavar "ARG"))
+
 dotEnv :: MonadIO m => Options -> m ()
 dotEnv opts = liftIO $ do
   mapM_ (loadFile (overload opts)) (files opts)
-  code <- system (program opts)
+  -- 'system' is used, so shell expansion is made
+  code <- system (program opts ++ concatMap (" " ++) (args opts))
   exitWith code

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,8 +17,8 @@ import System.Exit (exitWith)
 
 data Options = Options
   { files    :: [String]
-  , program  :: String
   , overload :: Bool
+  , program  :: String
   } deriving (Show)
 
 main :: IO ()
@@ -37,11 +37,11 @@ config = Options
                   <> metavar "FILE"
                   <> help "File to read for options" ))
 
-     <*> argument str (metavar "PROGRAM")
-
      <*> switch ( long "overload"
                   <> short 'o'
                   <> help "Specify this flag to override existing variables" )
+
+     <*> argument str (metavar "PROGRAM")
 
 dotEnv :: MonadIO m => Options -> m ()
 dotEnv opts = liftIO $ do


### PR DESCRIPTION
By accepting multiple arguments and concatening them back `dotenv` cli is more convenient:

```
 % stack exec -- dotenv -h                           
dotenv - loads options from dotenv files

Usage: dotenv (-f|--file FILE) [-o|--overload] PROGRAM [ARG]
  Runs PROGRAM after loading options from FILE

Available options:
  -h,--help                Show this help text
  -f,--file FILE           File to read for options
  -o,--overload            Specify this flag to override existing variables

% cat .env               
FOO=foo1
BAR=bar2

% stack exec -- dotenv -f .env -- echo '$FOO' '$BAR'
foo1 bar2

% stack exec -- dotenv -f .env -- echo example '$FOO' '$BAR'
example foo1 bar2
```