### PR TITLE
Allow blank variables on UNIX

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,6 +18,7 @@ import System.Exit (exitWith)
 data Options = Options
   { files    :: [String]
   , overload :: Bool
+  , blanks   :: Bool
   , program  :: String
   , args     :: [String]
   } deriving (Show)
@@ -42,13 +43,17 @@ config = Options
                   <> short 'o'
                   <> help "Specify this flag to override existing variables" )
 
+     <*> switch ( long "allow-empty-values"
+                  <> short 'b'
+                  <> help "Allow blank variables (unix only)" )
+
      <*> argument str (metavar "PROGRAM")
 
      <*> many (argument str (metavar "ARG"))
 
 dotEnv :: MonadIO m => Options -> m ()
 dotEnv opts = liftIO $ do
-  mapM_ (loadFile (overload opts)) (files opts)
+  mapM_ (loadFile (overload opts) (blanks opts)) (files opts)
   code <- system (program opts ++ programArguments)
   exitWith code
   where

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -72,6 +72,7 @@ library
                       , Configuration.Dotenv.Parse
                       , Configuration.Dotenv.ParsedVariable
                       , Configuration.Dotenv.Text
+                      , System.Environment.Dotenv
 
   build-depends:         base >=4.6 && <5.0
                        , base-compat >= 0.4
@@ -79,6 +80,9 @@ library
                        , text
                        , transformers >=0.4 && < 0.6
                        , exceptions >= 0.8 && < 0.9
+  if !os(windows)
+    build-depends:
+                       unix >= 2.7 && < 2.8
 
   hs-source-dirs:      src
   ghc-options:         -Wall
@@ -99,6 +103,7 @@ test-suite dotenv-test
                        , Configuration.Dotenv.Text
                        , Configuration.Dotenv.Parse
                        , Configuration.Dotenv.ParsedVariable
+                       , System.Environment.Dotenv
 
   build-depends:       base >=4.6 && <5.0
                      , base-compat >= 0.4
@@ -109,6 +114,9 @@ test-suite dotenv-test
                      , transformers >=0.4 && < 0.6
                      , exceptions >= 0.8 && < 0.9
                      , hspec-megaparsec >= 0.2 && < 0.4
+  if !os(windows)
+    build-depends:
+                       unix >= 2.7 && < 2.8
 
   if flag(dev)
     ghc-options:      -Wall -Werror

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -35,21 +35,21 @@ spec = do
     it "loads the given list of configuration options to the environment" $ do
       lookupEnv "foo" `shouldReturn` Nothing
 
-      load False [("foo", "bar")]
+      load False True [("foo", "bar")]
 
       lookupEnv "foo" `shouldReturn` Just "bar"
 
     it "preserves existing settings when overload is false" $ do
       setEnv "foo" "preset" True
 
-      load False [("foo", "new setting")]
+      load False True [("foo", "new setting")]
 
       lookupEnv "foo" `shouldReturn` Just "preset"
 
     it "overrides existing settings when overload is true" $ do
       setEnv "foo" "preset" True
 
-      load True [("foo", "new setting")]
+      load True True [("foo", "new setting")]
 
       lookupEnv "foo" `shouldReturn` Just "new setting"
 
@@ -57,30 +57,37 @@ spec = do
     it "can set blank variable values" $ do
       lookupEnv "foo" `shouldReturn` Nothing
 
-      load False [("foo", "")]
+      load False True [("foo", "")]
 
       lookupEnv "foo" `shouldReturn` Just ""
+
+    it "can ignore blank variables" $ do
+      lookupEnv "foo" `shouldReturn` Nothing
+
+      load False False [("foo", "")]
+
+      lookupEnv "foo" `shouldReturn` Nothing
 #endif
 
   describe "loadFile" $ after_ (unsetEnv "DOTENV") $ do
     it "loads the configuration options to the environment from a file" $ do
       lookupEnv "DOTENV" `shouldReturn` Nothing
 
-      loadFile False "spec/fixtures/.dotenv"
+      loadFile False True "spec/fixtures/.dotenv"
 
       lookupEnv "DOTENV" `shouldReturn` Just "true"
 
     it "respects predefined settings when overload is false" $ do
       setEnv "DOTENV" "preset" True
 
-      loadFile False "spec/fixtures/.dotenv"
+      loadFile False True "spec/fixtures/.dotenv"
 
       lookupEnv "DOTENV" `shouldReturn` Just "preset"
 
     it "overrides predefined settings when overload is true" $ do
       setEnv "DOTENV" "preset" True
 
-      loadFile True "spec/fixtures/.dotenv"
+      loadFile True True "spec/fixtures/.dotenv"
 
       lookupEnv "DOTENV" `shouldReturn` Just "true"
 
@@ -109,9 +116,9 @@ spec = do
   describe "onMissingFile" $ after_ (unsetEnv "DOTENV") $ do
     context "when target file is present" $
       it "loading works as usual" $ do
-        onMissingFile (loadFile True "spec/fixtures/.dotenv") (return ())
+        onMissingFile (loadFile True True "spec/fixtures/.dotenv") (return ())
         lookupEnv "DOTENV" `shouldReturn` Just "true"
     context "when target file is missing" $
       it "executes supplied handler instead" $
-        onMissingFile (True <$ loadFile True "spec/fixtures/foo") (return False)
+        onMissingFile (True <$ loadFile True True "spec/fixtures/foo") (return False)
           `shouldReturn` False

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -17,10 +17,11 @@ import Data.Functor ((<$>))
 import Control.Applicative ((<$))
 #endif
 
+import System.Environment.Dotenv (setEnv)
 #if MIN_VERSION_base(4,7,0)
-import System.Environment (setEnv, unsetEnv)
+import System.Environment (unsetEnv)
 #else
-import System.Environment.Compat (setEnv, unsetEnv)
+import System.Environment.Compat (unsetEnv)
 #endif
 
 {-# ANN module "HLint: ignore Reduce duplication" #-}
@@ -39,18 +40,27 @@ spec = do
       lookupEnv "foo" `shouldReturn` Just "bar"
 
     it "preserves existing settings when overload is false" $ do
-      setEnv "foo" "preset"
+      setEnv "foo" "preset" True
 
       load False [("foo", "new setting")]
 
       lookupEnv "foo" `shouldReturn` Just "preset"
 
     it "overrides existing settings when overload is true" $ do
-      setEnv "foo" "preset"
+      setEnv "foo" "preset" True
 
       load True [("foo", "new setting")]
 
       lookupEnv "foo" `shouldReturn` Just "new setting"
+
+#ifndef mingw32_HOST_OS
+    it "can set blank variable values" $ do
+      lookupEnv "foo" `shouldReturn` Nothing
+
+      load False [("foo", "")]
+
+      lookupEnv "foo" `shouldReturn` Just ""
+#endif
 
   describe "loadFile" $ after_ (unsetEnv "DOTENV") $ do
     it "loads the configuration options to the environment from a file" $ do
@@ -61,14 +71,14 @@ spec = do
       lookupEnv "DOTENV" `shouldReturn` Just "true"
 
     it "respects predefined settings when overload is false" $ do
-      setEnv "DOTENV" "preset"
+      setEnv "DOTENV" "preset" True
 
       loadFile False "spec/fixtures/.dotenv"
 
       lookupEnv "DOTENV" `shouldReturn` Just "preset"
 
     it "overrides predefined settings when overload is true" $ do
-      setEnv "DOTENV" "preset"
+      setEnv "DOTENV" "preset" True
 
       loadFile True "spec/fixtures/.dotenv"
 

--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -22,15 +22,9 @@ import Configuration.Dotenv.Parse (configParser)
 import Configuration.Dotenv.ParsedVariable (interpolateParsedVariables)
 import Control.Monad.Catch
 import Control.Monad.IO.Class (MonadIO(..))
-import System.Environment (lookupEnv)
 import System.IO.Error (isDoesNotExistError)
 import Text.Megaparsec (parse)
-
-#if MIN_VERSION_base(4,7,0)
-import System.Environment (setEnv)
-#else
-import System.Environment.Compat (setEnv)
-#endif
+import System.Environment.Dotenv (setEnv)
 
 -- | Loads the given list of options into the environment. Optionally
 -- override existing variables with values from Dotenv files.
@@ -64,16 +58,7 @@ parseFile f = do
     Right options -> liftIO $ interpolateParsedVariables options
 
 applySetting :: MonadIO m => Bool -> (String, String) -> m ()
-applySetting override (key, value) =
-  if override then
-    liftIO $ setEnv key value
-
-  else do
-    res <- liftIO $ lookupEnv key
-
-    case res of
-      Nothing -> liftIO $ setEnv key value
-      Just _  -> return ()
+applySetting override (key, value) = liftIO $ setEnv key value override
 
 -- | The helper allows to avoid exceptions in the case of missing files and
 -- perform some action instead.

--- a/src/System/Environment/Dotenv.hs
+++ b/src/System/Environment/Dotenv.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE CPP #-}
+
+module System.Environment.Dotenv (setEnv) where
+
+#ifdef mingw32_HOST_OS
+import System.Environment (lookupEnv)
+#if MIN_VERSION_base(4,7,0)
+import qualified System.Environment as W (setEnv)
+#else
+import qualified System.Environment.Compat as W (setEnv)
+#endif
+#else
+import System.Posix.Env (setEnv)
+#endif
+
+#ifdef mingw32_HOST_OS
+setEnv :: String -> String -> Bool -> IO ()
+setEnv key value override =
+  if override then W.setEnv key value
+  else do
+    res <- lookupEnv key
+
+    case res of
+      Nothing -> W.setEnv key value
+      Just _  -> return ()
+#endif


### PR DESCRIPTION
Here is the work to allow blank variables on UNIX machines (#48). Let me download and set up a Windows VM to test this on before merging it in.