### PR TITLE
Add version to the CLI, close #60

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,11 +3,13 @@
 
 module Main where
 
+import Data.Version (showVersion)
 #if MIN_VERSION_optparse_applicative(0,13,0)
 import Data.Monoid ((<>))
 #endif
 
 import Options.Applicative
+import Paths_dotenv (version)
 
 import Control.Monad (void)
 
@@ -35,10 +37,14 @@ main = do
     }
   system (program ++ concatMap (" " ++) args) >>= exitWith
     where
-      opts = info (helper <*> config)
+      opts = info (helper <*> versionOption <*> config)
         ( fullDesc
        <> progDesc "Runs PROGRAM after loading options from FILE"
        <> header "dotenv - loads options from dotenv files" )
+      versionOption =
+        infoOption
+          (showVersion version)
+          (long "version" <> short 'v' <> help "Show version of the program")
 
 config :: Parser Options
 config = Options

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -64,6 +64,7 @@ executable dotenv
                        , process
                        , text
                        , transformers >=0.4 && < 0.6
+  other-modules: Paths_dotenv
 
   hs-source-dirs:      app
   if flag(dev)


### PR DESCRIPTION
Output of the CLI:
```
➜  dotenv-hs git:(add_version_flag) ✗ stack exec dotenv
Missing: (-f|--dotenv DOTENV) PROGRAM

Usage: dotenv [-v|--version] (-f|--dotenv DOTENV) [--example DOTENV_EXAMPLE]
              [-o|--overload] PROGRAM [ARG]
  Runs PROGRAM after loading options from FILE
➜  dotenv-hs git:(add_version_flag) ✗ stack exec dotenv -- -v
0.5.0.1
➜  dotenv-hs git:(add_version_flag) ✗
```
@juanpaucar Could you take a look, please? To close #60 