### PR TITLE
Allow .env file as default, closes #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,27 @@ You can call dotenv from the command line in order to load settings
 from one or more dotenv file before invoking an executable:
 
 ```shell
-$ dotenv -e mydotenvfile myprogram
+$ dotenv -f mydotenvfile myprogram
+```
+
+The `-f` flag is optional, by default it looks for the `.env` file in the current
+working directory.
+
+```shell
+$ dotenv myprogram
 ```
 
 Aditionally you can pass arguments and flags to the program passed to
 Dotenv:
 
 ```shell
-$ dotenv -e mydotenvfile myprogram -- --myflag myargument
+$ dotenv -f mydotenvfile myprogram -- --myflag myargument
 ```
 
 or:
 
 ```shell
-$ dotenv -e mydotenvfile "myprogram --myflag myargument"
+$ dotenv -f mydotenvfile "myprogram --myflag myargument"
 ```
 
 Also, you can use a `--example` flag to use [dotenv-safe functionality](https://www.npmjs.com/package/dotenv-safe)
@@ -117,14 +124,14 @@ $ echo $FOO
 
 This will fail:
 ```shell
-$ dotenv -e .env --example .env.example "myprogram --myflag myargument"
+$ dotenv -f .env --example .env.example "myprogram --myflag myargument"
 > dotenv: Missing env vars! Please, check (this/these) var(s) (is/are) set: BAR
 ```
 
 This will succeed:
 ```shell
 $ export BAR=123 # Or you can do something like: "echo 'BAR=123' >> .env"
-$ dotenv -e .env --example .env.example "myprogram --myflag myargument"
+$ dotenv -f .env --example .env.example "myprogram --myflag myargument"
 ```
 
 Hint: The `env` program in most Unix-like environments prints out the

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,7 +14,7 @@ import Paths_dotenv (version)
 import Control.Monad (void)
 
 import Configuration.Dotenv (loadFile)
-import Configuration.Dotenv.Types (Config(..))
+import Configuration.Dotenv.Types (Config(..), defaultConfig)
 
 import System.Process (system)
 import System.Exit (exitWith)
@@ -33,7 +33,10 @@ main = do
   void $ loadFile Config
     { configExamplePath = dotenvExampleFiles
     , configOverride = override
-    , configPath = dotenvFiles
+    , configPath =
+        if null dotenvFiles
+          then configPath defaultConfig
+          else dotenvFiles
     }
   system (program ++ concatMap (" " ++) args) >>= exitWith
     where
@@ -48,7 +51,7 @@ main = do
 
 config :: Parser Options
 config = Options
-     <$> some (strOption (
+     <$> many (strOption (
                   long "dotenv"
                   <> short 'f'
                   <> metavar "DOTENV"


### PR DESCRIPTION
@juanpaucar Could you take a look, please? It closes #62

This is a workaround since `value` from `optparser-applicative` doesn't work for `some` or `many`.