### PR TITLE
Fix module description markup (Configuration.Dotenv.Types)

### DIFF
--- a/src/Configuration/Dotenv/Types.hs
+++ b/src/Configuration/Dotenv/Types.hs
@@ -1,4 +1,4 @@
-{- |
+-- |
 -- Module      :  Configuration.Dotenv.Types
 -- Copyright   :  © 2015–2017 Stack Builders Inc.
 -- License     :  MIT
@@ -8,7 +8,6 @@
 -- Portability :  portable
 --
 -- Provides the types with extra options for loading a dotenv file.
--}
 
 module Configuration.Dotenv.Types
   ( Config(..)


### PR DESCRIPTION
The current module description markup for `Configuration.Dotenv.Types` uses both `{- |` and `--`, which yields:

<img width="1649" alt="screen shot 2017-12-27 at 4 32 24 pm" src="https://user-images.githubusercontent.com/584947/34394144-58bb4e12-eb25-11e7-8782-8106e9db46d1.png">

Instead of (using this change):

<img width="1646" alt="screen shot 2017-12-27 at 4 33 05 pm" src="https://user-images.githubusercontent.com/584947/34394150-5e9a1e62-eb25-11e7-9de7-ec2c7c7c7773.png">
