### PR TITLE
Fix mismatch of env variable names in test

### DIFF
--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -86,7 +86,7 @@ spec = do
       context "when the needed env vars are not missing" $
         it "should succeed when loading all of the needed env vars" $ do
           setEnv "ANOTHER_ENV" "hello"
-          me <- getEnv "USER"
+          me <- getEnv "ME"
           home <- getEnv "HOME"
           loadFile config `shouldReturn` [("DOTENV","true"),("UNICODE_TEST","Manab\237"),("ENVIRONMENT", home),("PREVIOUS","true"),("ME", me),("ANOTHER_ENV","")]
           lookupEnv "DOTENV" `shouldReturn` Just "true"


### PR DESCRIPTION
This test was failing, and now succeeds. I'm guessing this was the intention, because I don't see `USER` mentioned anywhere else.