### PR TITLE
Reexport defaultConfig

### DIFF
--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -32,7 +32,7 @@ import Configuration.Dotenv.Parse (configParser)
 import Configuration.Dotenv.ParsedVariable (interpolateParsedVariables)
 import Configuration.Dotenv.Scheme
 import Configuration.Dotenv.Scheme.Types (ValidatorMap, defaultValidatorMap)
-import Configuration.Dotenv.Types (Config(..))
+import Configuration.Dotenv.Types (Config(..), defaultConfig)
 import Control.Monad.Catch
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.List (union, intersectBy, unionBy)


### PR DESCRIPTION
There are writting `import Configuration.Dotenv (loadFile, defaultConfig)` in README.
But `defaultConfig` is not reexport in `Configuration.Dotenv` module.

Occur error when write Main.hs like README:

```
Main.hs:17:42: error:
    Module ‘Configuration.Dotenv’ does not export ‘defaultConfig’
   |                             
17 | import           Configuration.Dotenv   (defaultConfig, loadFile)
   |                                          ^^^^^^^^^^^^^
```

So, need to explicit reexport `defaultConfig` if not change README.