### PR TITLE
Hide helper modules in other-modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## MASTER
+## Dotenv 0.7.0.0
+* Hide helper modules in other-modules
+
 ## Dotenv 0.6.0.3
 * Reexport `defaultConfig` in `Configuration.Dotenv` (thanks to: matsubara0507)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,9 +13,12 @@ import Paths_dotenv (version)
 
 import Control.Monad (void, unless)
 
-import Configuration.Dotenv (loadFile, loadSafeFile)
-import Configuration.Dotenv.Types (Config(..), defaultConfig)
-import Configuration.Dotenv.Scheme.Parser ( defaultValidatorMap )
+import Configuration.Dotenv
+  (Config(..)
+  , loadFile
+  , loadSafeFile
+  , defaultConfig
+  , defaultValidatorMap)
 
 import System.Process (system)
 import System.Exit (exitWith)

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.6.0.3
+version:             0.7.0.0
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:
@@ -78,7 +78,7 @@ executable dotenv
 
 library
   exposed-modules:      Configuration.Dotenv
-                      , Configuration.Dotenv.Parse
+  other-modules:        Configuration.Dotenv.Parse
                       , Configuration.Dotenv.ParsedVariable
                       , Configuration.Dotenv.Text
                       , Configuration.Dotenv.Types


### PR DESCRIPTION
# Motivation
The dotenv documentation in Hackage shows that we export everything from out package:
![image](https://user-images.githubusercontent.com/8370088/48264598-0af4a580-e3f8-11e8-8180-ce30187ffcda.png)

However, people will only need to `import Configuration.Dotenv`.
![image](https://user-images.githubusercontent.com/8370088/48264693-66bf2e80-e3f8-11e8-8a70-233f46067b41.png)

Therefore, I consider we should hide our other modules in `other-modules`. This could be a breaking change and that is why I updated to `0.7.0.0`.