### PR TITLE
Update bounds for optparse-applicative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## MASTER
+## Dotenv 0.8.0.1
+* Support for `optparse-applicative-1.5.0`
+
 ## Dotenv 0.8.0.0
 * Add `Configuration.Dotenv.Environment` module exporting functions from `System.Environment`,
   `System.Environment.Compat`, or `System.Environment.Blank`, depending on `base` version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## MASTER
 ## Dotenv 0.8.0.1
-* Support for `optparse-applicative-1.5.0`
+* Support for `optparse-applicative-0.15`
 
 ## Dotenv 0.8.0.0
 * Add `Configuration.Dotenv.Environment` module exporting functions from `System.Environment`,

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.8.0.0
+version:             0.8.0.1
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:
@@ -61,7 +61,7 @@ executable dotenv
   build-depends:         base >=4.7 && <5.0
                        , base-compat >= 0.4
                        , dotenv
-                       , optparse-applicative >=0.11 && < 0.15
+                       , optparse-applicative >=0.11 && < 0.16
                        , megaparsec
                        , process
                        , text


### PR DESCRIPTION
* Support for `optparse-applicative-1.5.0`