### PR TITLE
Add support for GHC 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: haskell
 
 ghc:
+  - "8.6"
   - "8.4"
   - "8.2"
   - "8.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## MASTER
+## Dotenv 0.8.0.2
+* Add support for GHC 8.6
+
 ## Dotenv 0.8.0.1
 * Support for `optparse-applicative-0.15`
 

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.8.0.1
+version:             0.8.0.2
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,3 @@
-resolver: lts-12.12
+resolver: lts-13.28
 packages:
 - '.'
-extra-deps:
-- megaparsec-7.0.1
-- parser-combinators-1.0.0
-- hspec-megaparsec-2.0.0
-- process-1.6.3.0


### PR DESCRIPTION
Solves #105.

LTS 13.28 was released a few days ago and it also contains all packages marked before as `extra-deps` on `stack.yaml`.