### PR TITLE
[#107] change megaparsec version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## MASTER
+## Dotenv 0.8.0.3
+* Add suppport for `megaparsec-8.0.0`
+
 ## Dotenv 0.8.0.2
 * Add support for GHC 8.6
 

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -91,7 +91,7 @@ library
   build-depends:         base >=4.7 && <5.0
                        , base-compat >= 0.4
                        , directory
-                       , megaparsec >= 7.0.1 && < 8.0
+                       , megaparsec >= 7.0.1 && < 9.0
                        , containers
                        , process >= 1.6.3.0 && < 1.7
                        , text

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.8.0.2
+version:             0.8.0.3
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:


### PR DESCRIPTION
This pull request addresses issue [#107] 
It allows meparsec 8.0.0 