### PR TITLE
Format release notes with ChangeLog content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ deploy:
   file: "dotenv-linux-x86_64-static.tar.gz"
   skip_cleanup: true
   release_notes_file: "CHANGELOG.md"
+  edge: true
   draft: true
   on:
     branch: release-with-notes

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ deploy:
   script: ./github-releaser -draft -verbose
   skip_cleanup: true
   on:
+    branch: release-with-notes
     condition: $TRAVIS_HASKELL_VERSION == "8.6.5"
-    tags: true
+    tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_deploy: |
     tar -C dist/build/dotenv -cvf dotenv-linux-x86_64-static.tar.gz dotenv
     curl https://github.com/lindell/github-release-cli/releases/download/1.3.0/github-releaser-travis -L --output github-releaser && chmod +x github-releaser
     export GITHUB_OAUTH_TOKEN="$GITHUB_TRAVIS_DEPLOY"
-    export RELEASE_NAME=Dotenv-Release-v$(cabal exec dotenv -- --version)
+    export RELEASE_NAME=v$(cabal exec dotenv -- --version)
     export BODY=$(envsubst < ./CHANGELOG.md)
     export FILES=dotenv-linux-x86_64-static.tar.gz
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,17 @@ before_deploy: |
   if [[ $TRAVIS_HASKELL_VERSION == "8.6.5" ]]; then
     cabal install -f 'static'
     tar -C dist/build/dotenv -cvf dotenv-linux-x86_64-static.tar.gz dotenv
+    curl https://github.com/lindell/github-release-cli/releases/download/1.3.0/github-releaser-travis -L --output github-releaser && chmod +x github-releaser
+    export GITHUB_OAUTH_TOKEN="$GITHUB_TRAVIS_DEPLOY"
+    export RELEASE_NAME=Dotenv-Release-v$(cabal exec dotenv -- --version)
+    export BODY=$(envsubst < ./CHANGELOG.md)
+    export FILES=dotenv-linux-x86_64-static.tar.gz
   fi
 
 deploy:
-  provider: releases
-  api_key: "$GITHUB_TRAVIS_DEPLOY"
-  file: "dotenv-linux-x86_64-static.tar.gz"
+  provider: script
+  script: ./github-releaser -draft -verbose
   skip_cleanup: true
-  draft: true
   on:
     condition: $TRAVIS_HASKELL_VERSION == "8.6.5"
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: haskell
 
 ghc:
   - "8.6"
-#  - "8.4"
-#  - "8.2"
-#  - "8.0"
-#  - "7.10"
+  - "8.4"
+  - "8.2"
+  - "8.0"
+  - "7.10"
 
 before_deploy: |
   if [[ $TRAVIS_HASKELL_VERSION == "8.6.5" ]]; then
@@ -23,6 +23,5 @@ deploy:
   edge: true
   draft: true
   on:
-    branch: release-with-notes
     condition: $TRAVIS_HASKELL_VERSION == "8.6.5"
-    tags: false
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,24 @@ language: haskell
 
 ghc:
   - "8.6"
-  - "8.4"
-  - "8.2"
-  - "8.0"
-  - "7.10"
+#  - "8.4"
+#  - "8.2"
+#  - "8.0"
+#  - "7.10"
 
 before_deploy: |
   if [[ $TRAVIS_HASKELL_VERSION == "8.6.5" ]]; then
     cabal install -f 'static'
     tar -C dist/build/dotenv -cvf dotenv-linux-x86_64-static.tar.gz dotenv
-    curl https://github.com/lindell/github-release-cli/releases/download/1.3.0/github-releaser-travis -L --output github-releaser && chmod +x github-releaser
-    export GITHUB_OAUTH_TOKEN="$GITHUB_TRAVIS_DEPLOY"
-    export RELEASE_NAME=v$(cabal exec dotenv -- --version)
-    export BODY=$(envsubst < ./CHANGELOG.md)
-    export FILES=dotenv-linux-x86_64-static.tar.gz
   fi
 
 deploy:
-  provider: script
-  script: ./github-releaser -draft -verbose
+  provider: releases
+  api_key: "$GITHUB_TRAVIS_DEPLOY"
+  file: "dotenv-linux-x86_64-static.tar.gz"
   skip_cleanup: true
+  release_notes_file: "CHANGELOG.md"
+  draft: true
   on:
     branch: release-with-notes
     condition: $TRAVIS_HASKELL_VERSION == "8.6.5"


### PR DESCRIPTION
Solves part of #112 
## Description

I'm using `github-release-cli` to deploy the releases.

Example of draft release generated with this feature: https://github.com/stackbuilders/dotenv-hs/releases/tag/untagged-e5b89fbe11e4932ef8a5

## NOTES
We still need to remove the extra notes from previous releases form the ChangeLog.