### PR TITLE
Create stages, build on OS X, deploy to AWS and GH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,65 @@ ghc:
   - "8.0"
   - "7.10"
 
-before_deploy: |
-  if [[ $TRAVIS_HASKELL_VERSION == "8.6.5" ]]; then
-    cabal install -f 'static'
-    tar -C dist/build/dotenv -cvf dotenv-linux-x86_64-static.tar.gz dotenv
-  fi
+env:
+  global:
+    - PATH=$HOME/.local/bin:$PATH
+    # Envs for OS X
+    - GHC_VER="8.6.5"
+    - CABAL_VER="2.4.0.0"
+    - PATH=$HOME/Library/Python/2.7/bin:$PATH
+    - PATH=$HOME/.cabal/bin:$HOME/.ghcup/bin:$PATH
+    - PATH=$HOME/.ghcup/ghc/$GHC_VER:$HOME/.cabal/$CABAL_VER:$PATH
 
-deploy:
-  provider: releases
-  api_key: "$GITHUB_TRAVIS_DEPLOY"
-  file: "dotenv-linux-x86_64-static.tar.gz"
-  skip_cleanup: true
-  release_notes_file: "CHANGELOG.md"
-  edge: true
-  draft: true
-  on:
-    condition: $TRAVIS_HASKELL_VERSION == "8.6.5"
-    tags: true
+before_install:
+  - pip install --user awscli
+  - echo $(which pip)
+  - mkdir -p ~/$TRAVIS_BUILD_NUMBER
+  - aws s3 sync s3://dotenv-releases/$TRAVIS_BUILD_NUMBER ~/$TRAVIS_BUILD_NUMBER
+
+jobs:
+  include:
+    - stage: OS X build and test
+      language: generic
+      os: osx
+      addons: skip
+      before_install: sh .travis/ghcup.sh
+      install: cabal install --only-dependencies --enable-tests
+      script: cabal configure --enable-tests && cabal build && cabal test
+
+    - stage: OS X binary build
+      if: branch = master
+      language: generic
+      os: osx
+      install: |
+        sh .travis/ghcup.sh
+        cabal install --only-dependencies
+      script: sh .travis/travis_build.sh
+
+    - stage: Linux static binary build
+      if: branch = master
+      ghc: 8.6
+      script: sh .travis/travis_build.sh
+
+    - stage: Deploy to GitHub
+      language: generic
+      before_deploy:
+        - mv ~/$TRAVIS_BUILD_NUMBER/* $PWD
+      deploy:
+        provider: releases
+        api_key: "$GITHUB_TRAVIS_DEPLOY"
+        file:
+          - "dotenv-linux-x86_64-static.tar.gz"
+          - "dotenv-osx-x86_64-static.tar.gz"
+        skip_cleanup: true
+        release_notes_file: "CHANGELOG.md"
+        edge: true
+        draft: true
+        on:
+          tags: true
+      after_deploy:
+        - aws s3 rm --recursive s3://dotenv-releases/$TRAVIS_BUILD_NUMBER
+
+
+after_success:
+  - aws s3 sync ~/$TRAVIS_BUILD_NUMBER s3://dotenv-releases/$TRAVIS_BUILD_NUMBER

--- a/.travis/ghcup.sh
+++ b/.travis/ghcup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+( mkdir -p ~/.ghcup/bin && curl https://gitlab.haskell.org/haskell/ghcup/raw/master/ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup) && echo "success"
+ghcup install $GHC_VER
+ghcup install-cabal $CABAL_VER
+ghcup set $GHC_VER
+cabal update

--- a/.travis/travis_build.sh
+++ b/.travis/travis_build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ "$TRAVIS_OS_NAME" = "osx" ]
+then
+  cabal install
+else
+  cabal install -f 'static'
+fi
+
+tar -C dist/build/dotenv -cvf dotenv-$TRAVIS_OS_NAME-x86_64-static.tar.gz dotenv
+mv dotenv-$TRAVIS_OS_NAME-x86_64-static.tar.gz ~/$TRAVIS_BUILD_NUMBER/


### PR DESCRIPTION
## Description
* solves #112 
* build and test in OS X
* compiles in OS X and Linux
* releases first uploaded to AWS and then to GitHub

Draft release example: https://github.com/stackbuilders/dotenv-hs/releases/tag/untagged-9d411fa225924347522b