### PR TITLE
pick last instead of first value

### DIFF
--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -38,8 +38,9 @@ import           Configuration.Dotenv.Types          (Config (..),
 import           Control.Monad                       (liftM, when)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class              (MonadIO (..))
+import           Data.Function                       (on)
 import           Data.List                           (intersectBy, union,
-                                                      unionBy)
+                                                      unionBy, nubBy)
 import           System.Directory                    (doesFileExist)
 import           System.IO.Error                     (isDoesNotExistError)
 import           Text.Megaparsec                     (errorBundlePretty, parse)
@@ -76,7 +77,9 @@ loadFile Config{..} = do
               then readedVars `unionEnvs` neededVars
               else error $ "Missing env vars! Please, check (this/these) var(s) (is/are) set:" ++ concatMap ((++) " " . fst) neededVars
           else readedVars
-  mapM (applySetting configOverride) vars
+      -- prefer later in favour of earlier occurrences:
+      nubbedVars = reverse . nubBy ((==) `on` fst) $ reverse vars
+  mapM (applySetting configOverride) nubbedVars
 
 -- | Parses the given dotenv file and returns values /without/ adding them to
 -- the environment.


### PR DESCRIPTION
This makes it so that we prefer latest than earlier occurrences of variable
settings.

Before the change
-----------------

    $ cat > my_script.hs
    #!/bin/bash
    echo $FOO
    echo $GOO
    ^D

    $ cat > .env
    #!/bin/sh
    FOO=first
    GOO=second
    FOO=third
    ^D

    $ dotenv -f.env ./my_script.hs
    first
    second

After the change
----------------

    $ cat > my_script.hs
    #!/bin/bash
    echo $FOO
    echo $GOO
    ^D

    $ cat > .env
    #!/bin/sh
    FOO=first
    GOO=second
    FOO=third
    ^D

    $ dotenv -f.env ./my_script.hs
    third
    second

This makes dotenv-hs consistent with both Python's dotenv and Bash/Sh's source.

The implementation may look innefficient with

    reverse . nubBy (...) . reverse

however it is as efficient as the surrounding code which is _O(n^2)_ overall as
Data.List.union is _O(n^2)_ already.

The ultimate reverse may not be needed, but I have kept it so the order in
which variables are set is unchanged.

This fixes issue #121.