### PR TITLE
[#124] Allow optparse-applicative-0.16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## MASTER
+## Dotenv 0.8.0.6
+* Allow optparse-applicative-0.16.0.0
+
 ## Dotenv 0.8.0.5
 * Extend ghc support to 8.8 and 8.10
 

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.8.0.5
+version:             0.8.0.6
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:
@@ -67,7 +67,7 @@ executable dotenv
   build-depends:         base >=4.7 && <5.0
                        , base-compat >= 0.4
                        , dotenv
-                       , optparse-applicative >=0.11 && < 0.16
+                       , optparse-applicative >=0.11 && < 0.17
                        , megaparsec
                        , process
                        , text


### PR DESCRIPTION
I run some tests locally forcing `optparse-applicative-0.16.0.0` here are the results:

```diff
 resolver: lts-13.28
 packages:
 - '.'
+extra-deps:
+  - optparse-applicative-0.16.0.0

```

Dependencies:

```
➜ stack ls dependencies | grep optparse
optparse-applicative 0.16.0.0
```

Test output:

```
➜ stack test
...
dotenv> Test suite dotenv-test passed
```