### PR TITLE
Release to Github workflow. Change Cabal version to 2.4

### DIFF
--- a/.github/workflows/release-gh.yml
+++ b/.github/workflows/release-gh.yml
@@ -19,7 +19,7 @@ jobs:
         uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: "3.4"
+          cabal-version: "2.4"
       - name: Build package
         id: build
         run: |


### PR DESCRIPTION
# Issue #128  

## Description
This PR changes the cabal version to 2.4 for the release workflow (as it was in Travis CI) to fix (previous PR #130)