### PR TITLE
Update support for GHC 9.0.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.0.2", "8.2.2", "8.4.4", "8.6.5", "8.8.3", "8.10.1"]
+        ghc: ["8.6.5", "8.8.3", "8.10.1", "9.0.1"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
-            ghc: "8.10.1"
+            ghc: "9.0.1"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-gh.yml
+++ b/.github/workflows/release-gh.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.10.1"]
+        ghc: ["9.0.1"]
         os: [ubuntu-latest , macos-latest]
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## MASTER
+## Dotenv 0.9.0.1
+### Added
+* Support for GHC 9.0.1
 
 ## Dotenv 0.9.0.1
 * Allow optparse-applicative-0.17.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## MASTER
+## Dotenv 0.9.0.2
+### Added
+* Support for GHC = 9.0
+
+### Removed
+* Support for GHC < 8.6
 
 ## Dotenv 0.9.0.1
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## MASTER
-## Dotenv 0.9.0.1
-### Added
-* Support for GHC 9.0.1
 
 ## Dotenv 0.9.0.1
+### Added
 * Allow optparse-applicative-0.17.0.0
 
 ## Dotenv 0.9.0.0

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.9.0.1
+version:             0.9.0.2
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-03-17
+resolver: lts-19.0
 packages:
 - '.'
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2021-11-19
+resolver: nightly-2022-03-17
 packages:
 - '.'
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.13
+resolver: nightly-2021-11-19
 packages:
 - '.'
 extra-deps:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: optparse-applicative-0.17.0.0
 snapshots:
 - completed:
-    size: 617108
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/3/17.yaml
-    sha256: a78bbd52a6de7cd16d7ba7590d10a2de57438895e66448ca444bd6f3ae16d946
-  original: nightly-2022-03-17
+    size: 616897
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/0.yaml
+    sha256: bbf2be02f17940bac1f87cb462d4fb0c3355de6dcfc53d84f4f9ad3ee2164f65
+  original: lts-19.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532381
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/13.yaml
-    sha256: 6ee17f7996e5bc75ae4406250841f1362ad4196418a4d90a0615ff4f26ac98df
-  original: lts-16.13
+    size: 596812
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/11/19.yaml
+    sha256: d4ebfabe1a2cc08a1521073ab0c9fd00036350518bfdd148ea7316690f39504d
+  original: nightly-2021-11-19

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: optparse-applicative-0.17.0.0@sha256:0713e54cbb341e5cae979e2ac441eb3a5ff42e303001f432bd58c19e5638bdda,4967
+    pantry-tree:
+      size: 3124
+      sha256: 3b4398845ee6718fe2303870a5ab75bd190eb712fed2f22caaae30f790c490fd
+  original:
+    hackage: optparse-applicative-0.17.0.0
 snapshots:
 - completed:
-    size: 596812
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/11/19.yaml
-    sha256: d4ebfabe1a2cc08a1521073ab0c9fd00036350518bfdd148ea7316690f39504d
-  original: nightly-2021-11-19
+    size: 617108
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/3/17.yaml
+    sha256: a78bbd52a6de7cd16d7ba7590d10a2de57438895e66448ca444bd6f3ae16d946
+  original: nightly-2022-03-17


### PR DESCRIPTION
## Added
* Support GHC 9.0.1

## Removed
* Support older versions of GHC (< 8.6)
