### PR TITLE
Parse multi-word command interpolations

### DIFF
--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -95,6 +95,7 @@ library
                        , megaparsec >= 7.0.1 && < 10.0
                        , containers
                        , process >= 1.6.3.0 && < 1.7
+                       , shellwords >= 0.1.3.0
                        , text
                        , exceptions >= 0.8 && < 0.11
 
@@ -128,6 +129,7 @@ test-suite dotenv-test
                      , megaparsec
                      , hspec
                      , process
+                     , shellwords
                      , text
                      , exceptions >= 0.8 && < 0.11
                      , hspec-megaparsec >= 2.0 && < 3.0

--- a/spec/Configuration/Dotenv/ParseSpec.hs
+++ b/spec/Configuration/Dotenv/ParseSpec.hs
@@ -7,7 +7,7 @@ import Configuration.Dotenv.ParsedVariable (ParsedVariable(..),
                                             VarValue(..),
                                             VarFragment(..))
 import Data.Void (Void)
-import Test.Hspec (it, describe, Spec, hspec)
+import Test.Hspec (it, context, describe, Spec, hspec)
 import Test.Hspec.Megaparsec (shouldParse, shouldFailOn, shouldSucceedOn)
 import Text.Megaparsec (ParseErrorBundle, parse)
 
@@ -142,11 +142,26 @@ spec = describe "parse" $ do
   it "doesn't allow more configuration options after a quoted value" $
     parseConfig `shouldFailOn` "foo='bar'baz='buz'"
 
-  it "parses a command $(command)" $ do
-    parseConfig "FOO=$(command)"
-      `shouldParse` [ParsedVariable "FOO" (Unquoted [CommandInterpolation "command"])]
-    parseConfig "FOO=asdf_$(command)"
-      `shouldParse` [ParsedVariable "FOO" (Unquoted [VarLiteral "asdf_", CommandInterpolation "command"])]
+  context "$(command) interpolation" $ do
+    it "parses a simple command" $ do
+      parseConfig "FOO=$(command)"
+        `shouldParse` [ParsedVariable "FOO" (Unquoted [CommandInterpolation "command" []])]
+
+    it "parses a command anywhere in the value" $ do
+      parseConfig "FOO=asdf_$(command)"
+        `shouldParse` [ParsedVariable "FOO" (Unquoted [VarLiteral "asdf_", CommandInterpolation "command" []])]
+
+    it "parses a command with arguments" $ do
+      parseConfig "FOO=$(command arg1 arg2)"
+        `shouldParse` [ParsedVariable "FOO" (Unquoted [CommandInterpolation "command" ["arg1", "arg2"]])]
+
+    it "parses a command with quoted arguments" $ do
+      parseConfig "FOO=$(command \"arg 1\" arg2)"
+        `shouldParse` [ParsedVariable "FOO" (Unquoted [CommandInterpolation "command" ["arg 1", "arg2"]])]
+
+    it "parses a command with arguments separated by newlines" $ do
+      parseConfig "FOO=$(command \"arg 1\"\narg2\n)"
+        `shouldParse` [ParsedVariable "FOO" (Unquoted [CommandInterpolation "command" ["arg 1", "arg2"]])]
 
   it "parses empty content (when the file is empty)" $
     parseConfig `shouldSucceedOn` ""

--- a/src/Configuration/Dotenv/Parse.hs
+++ b/src/Configuration/Dotenv/Parse.hs
@@ -20,11 +20,11 @@ import           Configuration.Dotenv.ParsedVariable
 import           Control.Applicative                 (empty, many, some, (<|>))
 import           Control.Monad                       (void)
 import           Data.Void                           (Void)
+import qualified ShellWords
 import           Text.Megaparsec                     (Parsec, anySingle,
                                                       between, eof, noneOf,
                                                       oneOf, sepEndBy, (<?>))
-import           Text.Megaparsec.Char                (alphaNumChar, char,
-                                                      digitChar, eol,
+import           Text.Megaparsec.Char                (char, digitChar, eol,
                                                       letterChar, spaceChar)
 import qualified Text.Megaparsec.Char.Lexer          as L
 
@@ -76,9 +76,11 @@ interpolatedValueVarInterpolation = VarInterpolation <$>
     symbol                = L.symbol sc
 
 interpolatedValueCommandInterpolation :: Parser VarFragment
-interpolatedValueCommandInterpolation =
-  CommandInterpolation
-    <$> between (symbol "$(") (symbol ")") (many alphaNumChar)
+interpolatedValueCommandInterpolation = do
+  ws <- between (symbol "$(") (symbol ")") ShellWords.parser
+  pure $ case ws of
+      (commandName:arguments) -> CommandInterpolation commandName arguments
+      _ -> CommandInterpolation "echo" [""]
     where
       symbol = L.symbol sc
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,4 @@ packages:
 - '.'
 extra-deps:
 - optparse-applicative-0.17.0.0
+- shellwords-0.1.3.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       sha256: 3b4398845ee6718fe2303870a5ab75bd190eb712fed2f22caaae30f790c490fd
   original:
     hackage: optparse-applicative-0.17.0.0
+- completed:
+    hackage: shellwords-0.1.3.0@sha256:baf03b1e80dbc5dffbe6ba5451ee7c389ac39e3e2f9c24030c26a639522a1032,2226
+    pantry-tree:
+      size: 496
+      sha256: ce076c4ec323107f8e84d25147b4f7c865e8cd27d804f384b9d1e2d5706ba0c3
+  original:
+    hackage: shellwords-0.1.3.0
 snapshots:
 - completed:
     size: 616897


### PR DESCRIPTION
The previous implementation only parsed alphanumeric values within
`$()`, which meant reasonable commands like `foo.sh`, `bin/foo`, or
`foo-bar` would all be rejected.

This commit does more than relax the character set, it uses the
[shellwords][] package to parse multiple words, as a shell would, then
passes the command and any arguments to `proc`.

[shellwords]: https://hackage.haskell.org/package/shellwords

This ensures correct parsing of strings like,

    echo hi\ there
    => ["echo", "hi there"]

    cmd --"this is valid"
    => ["cmd", "--this is valid"]

    cmd --this="Is \"also\" valid"
    => ["cmd", "--this=Is \"also\" valid"]

A note about security: this implementation was originally suggested as a
safer alternative to slurping up all content between `$(` and `)` and
passing it to `shell`. I now see that it is not actually any safer, as
the following example should show:

    FOO=$(echo 'if this were unsafe to pass to shell')
    BAR=$(sh -c "echo 'then this is just as unsafe'")

If we truly don't trust this input, the whole idea of interpolated
commands is suspect. The original mechanism is problematic even with the
restricted parser, and a naive parse-to-shell would be no more or less
problematic.

I think it's reasonable to trust the input, which means any of these
approaches are acceptable. In an ideal world, we'd add a switch in
`Config` to disable this feature for the security concious.

That said, shellwords does bring (at least) two conveniences:

- It correctly handles escaped or quoted ")" characters

  For example,

      FILES=$( find \( -name '*.hs' -o -name '*.hi' \) )

  Without shellwords, we'd still want to account for this ourselves, so
  I think a totally naive parser is off the table.

- It sets up the process tree without an intermediate shell

  This almost certainly doesn't matter as these are so short-lived, but
  in rare cases it can ensure better signal handling.
