### PR TITLE
chore: Go back to previous return type for loadFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## MASTER
 ## Dotenv 0.10.0.0
-### Added
+### Modified
 * `loadFile` change return type (back to `m ()`)
 
 ## Dotenv 0.9.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## MASTER
+## Dotenv 0.10.0.0
+### Added
+* `loadFile` change return type (back to `m ()`)
+
 ## Dotenv 0.9.0.3
 ### Added
 * Parse multi-word command interpolations (Kudos to @pbrisbin)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,7 +12,6 @@ import           Options.Applicative
 import           Paths_dotenv         (version)
 
 import           Configuration.Dotenv (Config (..), defaultConfig, loadFile)
-import           Control.Monad        (void)
 import           System.Exit          (exitWith)
 import           System.Process       (system)
 
@@ -41,7 +40,7 @@ main = do
                 else dotenvFiles
           }
    in do
-     void $ loadFile configDotenv
+     loadFile configDotenv
      system (program ++ concatMap (" " ++) args) >>= exitWith
        where
          opts = info (helper <*> versionOption <*> config)

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.9.0.3
+version:             0.10.0.0
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -12,7 +12,7 @@ import           Configuration.Dotenv.Types       (Config (..))
 
 import           Test.Hspec
 
-import           Control.Monad                    (liftM, void)
+import           Control.Monad                    (liftM)
 import           Data.Maybe                       (fromMaybe)
 import           System.Process                   (readCreateProcess, shell)
 
@@ -47,21 +47,21 @@ spec = do
     it "loads the configuration options to the environment from a file" $ do
       lookupEnv "DOTENV" `shouldReturn` Nothing
 
-      void $ loadFile sampleConfig
+      loadFile sampleConfig
 
       lookupEnv "DOTENV" `shouldReturn` Just "true"
 
     it "respects predefined settings when overload is false" $ do
       setEnv "DOTENV" "preset"
 
-      void $ loadFile sampleConfig
+      loadFile sampleConfig
 
       lookupEnv "DOTENV" `shouldReturn` Just "preset"
 
     it "overrides predefined settings when overload is true" $ do
       setEnv "DOTENV" "preset"
 
-      void $ loadFile sampleConfig { configOverride = True }
+      loadFile sampleConfig { configOverride = True }
 
       lookupEnv "DOTENV" `shouldReturn` Just "true"
 
@@ -70,7 +70,7 @@ spec = do
       context "when the needed env vars are missing" $
         it "should fail with an error call" $ do
           unsetEnv "ANOTHER_ENV"
-          void $ loadFile config `shouldThrow` anyErrorCall
+          loadFile config `shouldThrow` anyErrorCall
 
       context "when the needed env vars are not missing" $
         it "should succeed when loading all of the needed env vars" $ do
@@ -79,7 +79,7 @@ spec = do
           home <- fromMaybe "" <$> lookupEnv "HOME"
 
           -- Load envs
-          void $ loadFile config
+          loadFile config
 
           -- Check existing envs
           lookupEnv "ENVIRONMENT" `shouldReturn` Just home
@@ -124,7 +124,7 @@ spec = do
   describe "onMissingFile" $ after_ clearEnvs $ do
     context "when target file is present" $
       it "loading works as usual" $ do
-        void $ onMissingFile (loadFile sampleConfig {configOverride = True}) (return [])
+        onMissingFile (loadFile sampleConfig {configOverride = True}) (return ())
         lookupEnv "DOTENV" `shouldReturn` Just "true"
 
     context "when target file is missing" $
@@ -138,7 +138,7 @@ spec = do
         loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv", "spec/fixtures/.dotenv"], allowDuplicates = False }
           `shouldThrow` anyIOException
       it "works as usual when there is no duplicated keys" $ do
-        void $ loadFile sampleConfig { allowDuplicates = False }
+        loadFile sampleConfig { allowDuplicates = False }
         lookupEnv "DOTENV" `shouldReturn` Just "true"
 
 sampleConfig :: Config

--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -57,7 +57,7 @@ load override kv =
 loadFile ::
      MonadIO m
   => Config -- ^ Dotenv configuration
-  -> m [(String, String)] -- ^ Environment variables loaded
+  -> m ()
 loadFile config@Config {..} = do
   environment <- liftIO getEnvironment
   readVars <- fmap concat (mapM parseFile configPath)
@@ -75,7 +75,7 @@ loadFile config@Config {..} = do
                       concatMap ((++) " " . fst) neededVars
           else readVars
   unless allowDuplicates $ (lookUpDuplicates . map fst) vars
-  runReaderT (mapM applySetting vars) config
+  runReaderT (mapM_ applySetting vars) config
 
 -- | Parses the given dotenv file and returns values /without/ adding them to
 -- the environment.


### PR DESCRIPTION
# Change
After reviewing the question described by @nsaunders I think it would be best
to return to the initial return value for `loadFile`. It would make more sense
since it's an action that doesn't need to return the list of environment variables
loaded. It's main purpose is to load the envs from a file before running another action.
