### PR TITLE
Fix unexpected error with preset ENV and .env.example

### DIFF
--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -96,7 +96,7 @@ library
                        , shellwords >= 0.1.3.0
                        , text
                        , exceptions >= 0.8 && < 0.11
-                       , mtl >= 2.3 && < 2.4
+                       , mtl >= 2.2.2 && < 2.4
 
   hs-source-dirs:      src
   ghc-options:         -Wall

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -72,7 +72,7 @@ spec = do
           unsetEnv "ANOTHER_ENV"
           loadFile config `shouldThrow` anyErrorCall
 
-      context "when the needed env vars are not missing" $
+      context "when the needed env vars are not missing" $ do
         it "should succeed when loading all of the needed env vars" $ do
           -- Load extra information
           me <- init <$> readCreateProcess (shell "whoami") ""
@@ -87,6 +87,13 @@ spec = do
           lookupEnv "DOTENV" `shouldReturn` Just "true"
           lookupEnv "UNICODE_TEST" `shouldReturn` Just "Manabí"
           lookupEnv "ANOTHER_ENV" `shouldReturn` Just "hello"
+
+        it "succeeds when variable is preset" $ do
+          setEnv "DOTENV" "preset"
+
+          loadFile config
+
+          lookupEnv "DOTENV" `shouldReturn` Just "preset"
 
   describe "parseFile" $ after_ clearEnvs $ do
     it "returns variables from a file without changing the environment" $ do

--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -31,8 +31,7 @@ import           Control.Exception                   (throw)
 import           Control.Monad                       (unless, when)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class              (MonadIO (..))
-import           Data.List                           (intersectBy, union,
-                                                      unionBy)
+import           Data.List                           (intersectBy, unionBy)
 import           System.IO.Error                     (isDoesNotExistError)
 import           Text.Megaparsec                     (errorBundlePretty, parse)
 
@@ -61,7 +60,7 @@ loadFile config@Config {..} = do
   environment <- liftIO getEnvironment
   readVars <- fmap concat (mapM parseFile configPath)
   neededVars <- fmap concat (mapM parseFile configExamplePath)
-  let coincidences = (environment `union` readVars) `intersectEnvs` neededVars
+  let coincidences = (environment `unionEnvs` readVars) `intersectEnvs` neededVars
       cmpEnvs env1 env2 = fst env1 == fst env2
       intersectEnvs = intersectBy cmpEnvs
       unionEnvs = unionBy cmpEnvs

--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -67,7 +67,7 @@ loadFile config@Config {..} = do
       vars =
         if (not . null) neededVars
           then if length neededVars == length coincidences
-                 then readVars `unionEnvs` neededVars
+                 then readVars
                  else error $
                       "Missing env vars! Please, check (this/these) var(s) (is/are) set:" ++
                       concatMap ((++) " " . fst) neededVars

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,1 @@
-resolver: lts-19.0
-packages:
-- '.'
-extra-deps:
-- optparse-applicative-0.17.0.0
-- shellwords-0.1.3.0
+resolver: lts-20.11

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,24 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: optparse-applicative-0.17.0.0@sha256:0713e54cbb341e5cae979e2ac441eb3a5ff42e303001f432bd58c19e5638bdda,4967
-    pantry-tree:
-      size: 3124
-      sha256: 3b4398845ee6718fe2303870a5ab75bd190eb712fed2f22caaae30f790c490fd
-  original:
-    hackage: optparse-applicative-0.17.0.0
-- completed:
-    hackage: shellwords-0.1.3.0@sha256:baf03b1e80dbc5dffbe6ba5451ee7c389ac39e3e2f9c24030c26a639522a1032,2226
-    pantry-tree:
-      size: 496
-      sha256: ce076c4ec323107f8e84d25147b4f7c865e8cd27d804f384b9d1e2d5706ba0c3
-  original:
-    hackage: shellwords-0.1.3.0
+packages: []
 snapshots:
 - completed:
-    size: 616897
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/0.yaml
-    sha256: bbf2be02f17940bac1f87cb462d4fb0c3355de6dcfc53d84f4f9ad3ee2164f65
-  original: lts-19.0
+    sha256: adbc602422dde10cc330175da7de8609e70afc41449a7e2d6e8b1827aa0e5008
+    size: 649342
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/11.yaml
+  original: lts-20.11


### PR DESCRIPTION
We ran into this bug yesterday and it was super confusing. When a variable present in the `.env` or `.env.example` is pre-set in ENV, the validation has a bug that results in the key being in the "have" side of the equation twice. Since that adds an extra `(+1)` on the length of the "have" vs "need", the condition fails. Combined that with the fact that the error message just dumps out all of the "need" variables (instead of only what is missing) and we were scratching our heads for quite a while.

I recommend reviewing commit by commit. Let me know if you want me to rewrite out the post-factor commits, but I think they're useful enough to at least get your take on. Only the bug-fix commit is the one I'd really like to see landed.

---

### [Fix building on Stackage LTS](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/d3c8f20b08c15920597d6c16f06153919f5b2454)
[d3c8f20](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/d3c8f20b08c15920597d6c16f06153919f5b2454)

- Bump LTS, remove extra-deps
- Relax lower bound on mtl

### [Reproduce bug](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/afe8439cfffd8b1b0578eb195319286937c9548e)
[afe8439](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/afe8439cfffd8b1b0578eb195319286937c9548e)

### [Fix union/unionBy bug](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/eef61eabb1c5c767ed7c6ff6c6d6bb1b6a0699a8)
[eef61ea](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/eef61eabb1c5c767ed7c6ff6c6d6bb1b6a0699a8)

:point_up: **The important commit**

When the ambient environment is combined with the read values, this code
used `union` which compares key _and value_. This ends up duplicating
the variable in the list that's intersected (correctly on key only
there) and the difference in length results in the missing-variable
error unnecessarily. We already have a `unionEnvs` here that does the
right thing, we just have to use it.

### [Don't union in neededVars](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/376694a6b56a4c4e194ff382d3cb7dca0a0621f5)
[376694a](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/376694a6b56a4c4e194ff382d3cb7dca0a0621f5)

I could be missing something, but this didn't make sense to me:

If we're in this branch, then the `ambient+read` variables have the same
keys as needed, this means `read+needed` would only add those keys in
needed that are already in the `ambient`, which also means they need to
be set. Using only `read` here is functionally equivalent.

I'd also argue that actually _using_ anything from the `.env.example`
file (beyond validating the `.env`), if that were somehow happening
despite my analysis above, would be surprising to end users anyway.

### [Refactor .env.example check, improve error message](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/85feab4d674be1fd9bc965f8cd931640cd4bfa2e)
[85feab4](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/85feab4d674be1fd9bc965f8cd931640cd4bfa2e)

I found all of the `*By` and `cmpEnv` stuff really hard to follow and
unnecessarily complex. I think it led to the recently-fixed bug.

I find this version more straight forward. Hopefully it's objectively
less complicated too; it at least reduced two conditionals to one, which
is one quantitative improvement.

This version also made it easier to identify specifically the missing
keys for the error message. The code before would report *all* keys from
the example file(s) and leave it up to the user to sort out what was
present or not. Now we can report specific keys directly. I made some
minor quality-of-life improvements to the message too.

Before:

    Missing env vars! Please, check (this/these) var(s) (is/are) set:
    THIS_ENV, THAT_ENV, MISSING_ENV, THE_OTHER_ENV, ....

After (one `.env`, one `.env.example`):

    The following variables are present in .env.example, but not set in
    the current environment or .env: MISSING_ENV

After (many `.env`s, many `.env.example`s):

    The following variables are present in one of .env.example.1,
    .env.example.2, but not set in the current environment, or any of
    .env.1, .env.2: MISSING_ENV

This should be much less confusing to end-users.

### [Model unexpected empty list case in the types](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/0be626988e59f91f77c11dd15e9dff5900ff411a)
[0be6269](https://github.com/stackbuilders/dotenv-hs/pull/156/commits/0be626988e59f91f77c11dd15e9dff5900ff411a)