### PR TITLE
Introduced nubByLastVar vars before applying setting.

### DIFF
--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -48,6 +48,7 @@ data-dir: spec/fixtures/
 data-files:
   .dotenv
   .dotenv.example
+  .dotenv.dup
 
 flag static
   description:        Creates static binary.

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -43,6 +43,15 @@ spec = do
 
       lookupEnv "foo" `shouldReturn` Just "new setting"
 
+    it "loads the last set value in config list with duplicates" $ do
+      lookupEnv "foo" `shouldReturn` Nothing
+      lookupEnv "bar" `shouldReturn` Nothing
+
+      load False [("foo", "first"), ("bar", "second"), ("foo", "third")]
+
+      lookupEnv "foo" `shouldReturn` Just "third"
+      lookupEnv "bar" `shouldReturn` Just "second"
+
   describe "loadFile" $ before_ setupEnv $ after_ clearEnvs $  do
     it "loads the configuration options to the environment from a file" $ do
       lookupEnv "DOTENV" `shouldReturn` Nothing
@@ -64,6 +73,15 @@ spec = do
       loadFile sampleConfig { configOverride = True }
 
       lookupEnv "DOTENV" `shouldReturn` Just "true"
+
+    it "loads the last set value in dotenv file with duplicates" $ do
+      lookupEnv "FOO" `shouldReturn` Nothing
+      lookupEnv "BAR" `shouldReturn` Nothing
+
+      loadFile (Config ["spec/fixtures/.dotenv.dup"] [] False False True)
+
+      lookupEnv "FOO" `shouldReturn` Just "last"
+      lookupEnv "BAR" `shouldReturn` Just "tender"
 
     context "when the .env.example is present" $ do
       let config = sampleConfig { configExamplePath = ["spec/fixtures/.dotenv.example"]}

--- a/spec/fixtures/.dotenv.dup
+++ b/spec/fixtures/.dotenv.dup
@@ -1,0 +1,3 @@
+FOO=first
+BAR=tender
+FOO=last

--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -24,17 +24,19 @@ import           Configuration.Dotenv.Environment    (getEnvironment, lookupEnv,
                                                       setEnv)
 import           Configuration.Dotenv.Parse          (configParser)
 import           Configuration.Dotenv.ParsedVariable (interpolateParsedVariables)
-import           Configuration.Dotenv.Types          (Config (..), defaultConfig)
-import           Control.Monad.Trans                 (lift)
-import           Control.Monad.Reader                (ReaderT, ask, runReaderT)
+import           Configuration.Dotenv.Types          (Config (..),
+                                                      defaultConfig)
 import           Control.Exception                   (throw)
 import           Control.Monad                       (unless, when)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class              (MonadIO (..))
+import           Control.Monad.Reader                (ReaderT, ask, runReaderT)
+import           Control.Monad.Trans                 (lift)
 import           Data.Function                       (on)
-import           Data.List.NonEmpty                  (NonEmpty(..))
-import qualified Data.List.NonEmpty as NE
-import           Data.List                           ((\\), intercalate, union)
+import           Data.List                           (intercalate, union, (\\))
+import           Data.List.NonEmpty                  (NonEmpty (..))
+import qualified Data.List.NonEmpty                  as NE
+import           Data.Map                            (fromList, toList)
 import           System.IO.Error                     (isDoesNotExistError)
 import           Text.Megaparsec                     (errorBundlePretty, parse)
 
@@ -49,7 +51,7 @@ load ::
   -> [(String, String)] -- ^ List of values to be set in environment
   -> m ()
 load override kv =
-  runReaderT (mapM_ applySetting kv) defaultConfig {configOverride = override}
+  runReaderT (mapM_ applySetting (nubByLastVar kv)) defaultConfig {configOverride = override}
 
 -- | @loadFile@ parses the environment variables defined in the dotenv example
 -- file and checks if they are defined in the dotenv file or in the environment.
@@ -86,7 +88,7 @@ loadFile config@Config {..} = do
             ]
 
   unless allowDuplicates $ (lookUpDuplicates . map fst) vars
-  runReaderT (mapM_ applySetting vars) config
+  runReaderT (mapM_ applySetting (nubByLastVar vars)) config
  where
   showPaths :: String -> NonEmpty FilePath -> String
   showPaths _ (p:|[]) = p
@@ -156,3 +158,6 @@ lookUpDuplicates (x:xs) =
   if x `elem` xs
     then forbidDuplicates x
     else lookUpDuplicates xs
+
+nubByLastVar :: [(String, String)] -> [(String, String)]
+nubByLastVar = toList . fromList


### PR DESCRIPTION
- This PR addresses [issue #121](https://github.com/stackbuilders/dotenv-hs/issues/121)
- Mapping vars before setting in environment using function `nubByLastVar`.
- Added function [`nubByLastVar`](https://github.com/stackbuilders/dotenv-hs/compare/issue-121-dotenv-picks-last-value?expand=1#diff-28752b99ee8c901d2f3dead57a3943b5fe22dc7c15bf7ec272eee5e646f4843fR163) that yields a [`Data.Map`](https://hackage.haskell.org/package/containers-0.4.0.0/docs/Data-Map.html)  from a list and the returns back an ordered list of type `[(String), (String)]`. If the list contains more than one value for the same key, the last value for the key is retained.
