### PR TITLE
feat: Add --dry-run flag to print out variables without executing the program

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ need this functionality you can set `configExamplePath` to an empty list.
 A `False` in the `configVerbose` means that Dotenv will not print any message
 when loading the envs. A `True` means that Dotenv will print a message when a variable is loaded.
 
+`configDryRyn` is similar to `confifVerbose`, but it will print out the loaded variables prior to program execution.
+
 A `False` on `allowDuplicates` means that Dotenv will not allow duplicate keys, and instead it will throw
 an error. A `True` means that Dotenv will allow duplicate keys, and it will use the last one defined in the file (default behavior).
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ need this functionality you can set `configExamplePath` to an empty list.
 A `False` in the `configVerbose` means that Dotenv will not print any message
 when loading the envs. A `True` means that Dotenv will print a message when a variable is loaded.
 
-`configDryRyn` is similar to `confifVerbose`, but it will print out the loaded variables prior to program execution.
+`configDryRyn` is similar to `configVerbose`, but it will print out the loaded
+variables prior to program execution. When `configDryRyn` is `True`, Dotenv
+will not execute the program.
 
 A `False` on `allowDuplicates` means that Dotenv will not allow duplicate keys, and instead it will throw
 an error. A `True` means that Dotenv will allow duplicate keys, and it will use the last one defined in the file (default behavior).

--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ need this functionality you can set `configExamplePath` to an empty list.
 A `False` in the `configVerbose` means that Dotenv will not print any message
 when loading the envs. A `True` means that Dotenv will print a message when a variable is loaded.
 
-`configDryRyn` is similar to `configVerbose`, but it will print out the loaded
-variables prior to program execution. When `configDryRyn` is `True`, Dotenv
-will not execute the program.
+When `configDryRyn` is `True`, Dotenv will print out the loaded environment variables without executing the program.
 
 A `False` on `allowDuplicates` means that Dotenv will not allow duplicate keys, and instead it will throw
 an error. A `True` means that Dotenv will allow duplicate keys, and it will use the last one defined in the file (default behavior).
@@ -164,12 +162,14 @@ $ echo $FOO
 ```
 
 This will fail:
+
 ```shell
 $ dotenv -f .env --example .env.example "myprogram --myflag myargument"
 > dotenv: The following variables are present in .env.example, but not set in the current environment, or .env: BAR
 ```
 
 This will succeed:
+
 ```shell
 $ export BAR=123 # Or you can do something like: "echo 'BAR=123' >> .env"
 $ dotenv -f .env --example .env.example "myprogram --myflag myargument"
@@ -189,5 +189,6 @@ MIT, see [the LICENSE file](LICENSE).
 Do you want to contribute to this project? Please take a look at our [contributing guideline](/docs/CONTRIBUTING.md) to know how you can help us build it.
 
 ---
+
 <img src="https://cdn.stackbuilders.com/media/images/Sb-supports.original.png" alt="Stack Builders" width="50%"></img>
 [Check out our libraries](https://github.com/stackbuilders/) | [Join our team](https://www.stackbuilders.com/join-us/)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -78,7 +78,7 @@ config = Options
                   <> help "Specify this flag to print out the variables loaded and other useful insights" )
 
      <*> switch (  long "dry-run"
-                  <> help "Specify this flag to print out the variables loaded before executing the program" )
+                  <> help "Specify this flag to print out the variables loaded without executing the program" )
 
      <*> flag True False (  long "no-dups"
                   <> short 'D'

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -42,8 +42,10 @@ main = do
                 else dotenvFiles
           }
    in do
-     loadFile configDotenv
-     system (program ++ concatMap (" " ++) args) >>= exitWith
+    loadFile configDotenv
+    if configDryRun configDotenv
+      then putStrLn "[INFO]: Dry run mode enabled. Not executing the program."
+      else system (program ++ concatMap (" " ++) args) >>= exitWith
        where
          opts = info (helper <*> versionOption <*> config)
            ( fullDesc

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,6 +20,7 @@ data Options = Options
   , dotenvExampleFiles :: [String]
   , override           :: Bool
   , verbose            :: Bool
+  , dryRun             :: Bool
   , duplicates         :: Bool
   , program            :: String
   , args               :: [String]
@@ -33,6 +34,7 @@ main = do
           { configExamplePath = dotenvExampleFiles
           , configOverride = override
           , configVerbose = verbose
+          , configDryRun = dryRun
           , allowDuplicates = duplicates
           , configPath =
               if null dotenvFiles
@@ -72,6 +74,9 @@ config = Options
 
      <*> switch (  long "verbose"
                   <> help "Specify this flag to print out the variables loaded and other useful insights" )
+
+     <*> switch (  long "dry-run"
+                  <> help "Specify this flag to print out the variables loaded before executing the program" )
 
      <*> flag True False (  long "no-dups"
                   <> short 'D'

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -168,6 +168,9 @@ spec = do
 
   describe "onConfigDryRun" $ after_ clearEnvs $ do
     context "when dry-run is enabled " $ do
+      it "doesn't load variables" $ do
+        loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = True }
+        lookupEnv "DOTENV" `shouldReturn` Nothing
       it "does load variables" $ do
         loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = False }
         lookupEnv "DOTENV" `shouldReturn` Just "true"

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -168,9 +168,6 @@ spec = do
 
   describe "onConfigDryRun" $ after_ clearEnvs $ do
     context "when dry-run is enabled " $ do
-      it "doesn't load variables" $ do
-        loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = True }
-        lookupEnv "DOTENV" `shouldReturn` Nothing
       it "does load variables" $ do
         loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = False }
         lookupEnv "DOTENV" `shouldReturn` Just "true"

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -166,8 +166,8 @@ spec = do
         loadFile sampleConfig { allowDuplicates = False }
         lookupEnv "DOTENV" `shouldReturn` Just "true"
 
-  describe "onConfigDryRun" $ after_ clearEnvs $ do
-    context "when dry-run is enabled " $ do
+  describe "onConfigDryRun" $ after_ clearEnvs $
+    context "when dry-run is enabled " $
       it "loads the variables" $ do
         loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = True }
         lookupEnv "DOTENV" `shouldReturn` Just "true"

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -168,10 +168,6 @@ spec = do
 
   describe "onConfigDryRun" $ after_ clearEnvs $ do
     context "when dry-run is enabled " $ do
-      it "doesn't load variables" $ do
-        loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = True }
-        lookupEnv "DOTENV" `shouldReturn` Nothing
-      it "does load variables" $ do
         loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = False }
         lookupEnv "DOTENV" `shouldReturn` Just "true"
 

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -166,6 +166,15 @@ spec = do
         loadFile sampleConfig { allowDuplicates = False }
         lookupEnv "DOTENV" `shouldReturn` Just "true"
 
+  describe "onConfigDryRun" $ after_ clearEnvs $ do
+    context "when dry-run is enabled " $ do
+      it "doesn't load variables" $ do
+        loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = True }
+        lookupEnv "DOTENV" `shouldReturn` Nothing
+      it "does load variables" $ do
+        loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = False }
+        lookupEnv "DOTENV" `shouldReturn` Just "true"
+
 sampleConfig :: Config
 sampleConfig = Config ["spec/fixtures/.dotenv"] [] False False False True
 

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -78,7 +78,7 @@ spec = do
       lookupEnv "FOO" `shouldReturn` Nothing
       lookupEnv "BAR" `shouldReturn` Nothing
 
-      loadFile (Config ["spec/fixtures/.dotenv.dup"] [] False False True)
+      loadFile (Config ["spec/fixtures/.dotenv.dup"] [] False False False True)
 
       lookupEnv "FOO" `shouldReturn` Just "last"
       lookupEnv "BAR" `shouldReturn` Just "tender"
@@ -167,7 +167,7 @@ spec = do
         lookupEnv "DOTENV" `shouldReturn` Just "true"
 
 sampleConfig :: Config
-sampleConfig = Config ["spec/fixtures/.dotenv"] [] False False True
+sampleConfig = Config ["spec/fixtures/.dotenv"] [] False False False True
 
 clearEnvs :: IO ()
 clearEnvs =

--- a/spec/Configuration/DotenvSpec.hs
+++ b/spec/Configuration/DotenvSpec.hs
@@ -168,7 +168,8 @@ spec = do
 
   describe "onConfigDryRun" $ after_ clearEnvs $ do
     context "when dry-run is enabled " $ do
-        loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = False }
+      it "loads the variables" $ do
+        loadFile sampleConfig { configPath = ["spec/fixtures/.dotenv"], configDryRun = True }
         lookupEnv "DOTENV" `shouldReturn` Just "true"
 
 sampleConfig :: Config

--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -88,9 +88,7 @@ loadFile config@Config {..} = do
             ]
 
   unless allowDuplicates $ (lookUpDuplicates . map fst) vars
-  if configDryRun
-    then liftIO $ mapM_ (putStrLn . infoStr) vars
-    else runReaderT (mapM_ applySetting (nubByLastVar vars)) config
+  runReaderT (mapM_ applySetting (nubByLastVar vars)) config
  where
   showPaths :: String -> NonEmpty FilePath -> String
   showPaths _ (p:|[]) = p

--- a/src/Configuration/Dotenv.hs
+++ b/src/Configuration/Dotenv.hs
@@ -30,7 +30,8 @@ import           Control.Exception                   (throw)
 import           Control.Monad                       (unless, when)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class              (MonadIO (..))
-import           Control.Monad.Reader                (ReaderT, runReaderT)
+import           Control.Monad.Reader                (ReaderT, ask, runReaderT)
+import           Control.Monad.Trans                 (lift)
 import           Data.Foldable                       (traverse_)
 import           Data.Function                       (on)
 import           Data.List                           (intercalate, union, (\\))
@@ -51,7 +52,7 @@ load ::
   -> [(String, String)] -- ^ List of values to be set in environment
   -> m ()
 load override kv =
-  runReaderT (mapM_ (`applySetting` defaultConfig {configOverride = override}) (nubByLastVar kv)) defaultConfig {configOverride = override}
+  runReaderT (mapM_ applySetting (nubByLastVar kv)) defaultConfig {configOverride = override}
 
 -- | @loadFile@ parses the environment variables defined in the dotenv example
 -- file and checks if they are defined in the dotenv file or in the environment.
@@ -89,12 +90,10 @@ loadFile config@Config {..} = do
 
   unless allowDuplicates $ (lookUpDuplicates . map fst) vars
   if configDryRun
-    then
-      traverse_ (\kv -> do
-        result <- applySetting kv config
-        liftIO $ putStrLn $ infoStr result
-      ) (nubByLastVar vars)
-    else runReaderT (mapM_ (`applySetting` config) (nubByLastVar vars)) config
+    then do
+      let action = traverse_ (liftIO . putStrLn . infoStr) =<< mapM applySetting (nubByLastVar vars)
+      liftIO $ runReaderT action config
+    else runReaderT (mapM_ applySetting (nubByLastVar vars)) config
   where
     showPaths :: String -> NonEmpty FilePath -> String
     showPaths _ (p:|[]) = p
@@ -119,21 +118,22 @@ applySetting ::
   -> m (String, String)
 applySetting kv@(k, v) config = do
   if configOverride config
-    then info (configVerbose config) kv >> setEnv'
+    then setEnv'
     else do
       res <- liftIO $ lookupEnv k
       case res of
-        Nothing -> info (configVerbose config) kv >> setEnv'
+        Nothing ->  setEnv'
         Just _  -> return kv
   where
-    setEnv' = liftIO $ setEnv k v >> return kv
+   setEnv' = liftIO $ setEnv k v >> return kv
 
 -- | The function logs in console when a variable is loaded into the
 -- environment.
-info :: MonadIO m => Bool -> (String, String) -> m ()
-info configVerbose (key, value) = do
+info :: MonadIO m => (String, String) -> DotEnv m ()
+info (key, value) = do
+  Config {..} <- ask
   when configVerbose $
-    liftIO $
+    lift . liftIO $
     putStrLn $ infoStr (key, value)
 
 -- | The function prints out the variables

--- a/src/Configuration/Dotenv/Types.hs
+++ b/src/Configuration/Dotenv/Types.hs
@@ -23,6 +23,7 @@ data Config = Config
   , configExamplePath :: [FilePath] -- ^ The paths for the .env.example files
   , configOverride    :: Bool     -- ^ Flag to allow override env variables
   , configVerbose     :: Bool     -- ^ Flag to log the loaded variables and other useful information
+  , configDryRun      :: Bool     -- ^ Flag to print out the variables loaded without executing the program
   , allowDuplicates   :: Bool     -- ^ Flag to allow duplicate variables
   } deriving (Eq, Show)
 
@@ -35,6 +36,7 @@ defaultConfig =
     , configOverride = False
     , configPath = [ ".env" ]
     , configVerbose = False
+    , configDryRun = False
     , allowDuplicates = True
     }
 


### PR DESCRIPTION
This PR tackles the feature request outlined in https://github.com/stackbuilders/dotenv-hs/issues/159 

## Issue Description:
The current Dotenv CLI executes the program regardless of the provided environment variables, even if they are missing or do not meet the required criteria. This behavior poses a concern as it may lead to unintended consequences or errors.

## Proposed Solution:

To address this issue, this pull request introduces a new flag  --dry-run that allows users to examine the loaded environment variables without executing the program.
