### PR TITLE
chore: Update support up to GHC 9.6 and bump new version 0.12.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["9.6", "9.4", "9.2"]
+        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["9.2", "9.0", "8.10"]
+        ghc: ["9.6", "9.4", "9.2"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
@@ -32,7 +32,7 @@ jobs:
         uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: "3.6"
+          cabal-version: "3.8"
 
       - name: Update dependencies with Hackage
         run: cabal update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## MASTER
+## Dotenv 0.12.0.0
+### Modified
+* Ensure support from GHC 8.10 up to GHC 9.6
+
+### Possible breaking change
+* New attribute for `Config` data type to print env vars without actually
+running the command (kudos to @flandrade).
+
 ## Dotenv 0.11.0.2
 ### Modified
 * Allow optparse-applicative 0.18

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -34,6 +34,7 @@ description:
 license:             MIT
 license-file:        LICENSE
 author:              Justin Leitgeb
+tested-with:         ghc ==9.0 ghc ==9.4 ghc ==9.6
 maintainer:          hackage@stackbuilders.com
 copyright:           2015-Present Stack Builders Inc.
 category:            Configuration

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -1,5 +1,5 @@
 name:                dotenv
-version:             0.11.0.2
+version:             0.12.0.0
 synopsis:            Loads environment variables from dotenv files
 homepage:            https://github.com/stackbuilders/dotenv-hs
 description:
@@ -33,7 +33,7 @@ description:
   page for more information on this package.
 license:             MIT
 license-file:        LICENSE
-author:              Justin Leitge
+author:              Justin Leitgeb
 tested-with:         ghc ==8.10 ghc ==9.0 ghc ==9.2 ghc ==9.4 ghc ==9.6
 maintainer:          hackage@stackbuilders.com
 copyright:           2015-Present Stack Builders Inc.

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -33,8 +33,8 @@ description:
   page for more information on this package.
 license:             MIT
 license-file:        LICENSE
-author:              Justin Leitgeb
-tested-with:         ghc ==9.0 ghc ==9.4 ghc ==9.6
+author:              Justin Leitge
+tested-with:         ghc ==8.10 ghc ==9.0 ghc ==9.2 ghc ==9.4 ghc ==9.6
 maintainer:          hackage@stackbuilders.com
 copyright:           2015-Present Stack Builders Inc.
 category:            Configuration
@@ -63,7 +63,7 @@ flag dev
 
 executable dotenv
   main-is:             Main.hs
-  build-depends:         base >= 4.9 && < 5.0
+  build-depends:         base >= 4.14 && < 5.0
                        , base-compat >= 0.4
                        , dotenv
                        , optparse-applicative >= 0.11 && < 0.19


### PR DESCRIPTION
# Changes
- Increase support up to GHC 9.6
