### PR TITLE
feat: Add FromEnv to generically create values from env variables

### DIFF
--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -101,6 +101,7 @@ library
                        , exceptions >= 0.8 && < 0.11
                        , mtl >= 2.2.2 && < 2.4
                        , data-default-class >= 0.1.2 && < 0.2
+                       , casing
 
   hs-source-dirs:      src
   ghc-options:         -Wall

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -85,6 +85,7 @@ library
   exposed-modules:       Configuration.Dotenv
                        , Configuration.Dotenv.Internal
                        , Configuration.Dotenv.Environment
+                       , Configuration.Dotenv.FromEnv
   other-modules:         Configuration.Dotenv.Parse
                        , Configuration.Dotenv.ParsedVariable
                        , Configuration.Dotenv.Text
@@ -116,6 +117,7 @@ test-suite dotenv-test
   other-modules:         Configuration.DotenvSpec
                        , Configuration.Dotenv.TextSpec
                        , Configuration.Dotenv.ParseSpec
+                       , Configuration.Dotenv.FromEnvSpec
 
   build-depends:       base >= 4.9 && < 5.0
                      , dotenv

--- a/spec/Configuration/Dotenv/FromEnvSpec.hs
+++ b/spec/Configuration/Dotenv/FromEnvSpec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE DeriveAnyClass   #-}
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE TypeApplications #-}
+module Configuration.Dotenv.FromEnvSpec (main, spec) where
+
+import           GHC.Generics
+import           Test.Hspec                       (Spec, after_, describe,
+                                                   hspec, it, shouldBe,
+                                                   shouldSatisfy)
+
+import           Configuration.Dotenv.Environment (getEnvironment, setEnv,
+                                                   unsetEnv)
+import           Configuration.Dotenv.FromEnv
+import           Data.Maybe                       (fromJust, isJust)
+
+data Config = Config
+  { dbURL  :: !String
+  , apiKey :: !String
+  }
+  deriving (Eq, Show, Generic, FromEnv)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "fromEnv" $ after_ clearEnvs $ do
+    it "returns Nothing when the necessary environment variables are not set" $ do
+      config <- fromEnv_ @Config
+      config `shouldBe` Nothing
+
+    it "returns Nothing when only one environment variable is missing" $ do
+      setEnv "dbURL" "hello"
+      config <- fromEnv_ @Config
+      config `shouldBe` Nothing
+
+    it "returns the configuration object when all necessary variables are set" $ do
+      setEnv "dbURL" "hello"
+      setEnv "apiKey" "world"
+      config <- fromEnv_
+      config `shouldSatisfy` isJust
+      fromJust config `shouldBe` Config "hello" "world"
+
+    it "returns the configuration object when using different names for the environment variables" $ do
+      setEnv "DB_URL" "hello"
+      setEnv "API_KEY" "world"
+      let converter "dbURL"  = Just "DB_URL"
+          converter "apiKey" = Just "API_KEY"
+          converter _        = Nothing
+      config <- fromEnv converter
+      config `shouldSatisfy` isJust
+      fromJust config `shouldBe` Config "hello" "world"
+
+
+clearEnvs :: IO ()
+clearEnvs = getEnvironment >>= mapM_ unsetEnv . fmap fst

--- a/spec/Configuration/Dotenv/FromEnvSpec.hs
+++ b/spec/Configuration/Dotenv/FromEnvSpec.hs
@@ -27,28 +27,25 @@ spec :: Spec
 spec =
   describe "fromEnv" $ after_ clearEnvs $ do
     it "returns Nothing when the necessary environment variables are not set" $ do
-      config <- fromEnv_ @Config
+      config <- fromEnv @Config
       config `shouldBe` Nothing
 
     it "returns Nothing when only one environment variable is missing" $ do
       setEnv "dbURL" "hello"
-      config <- fromEnv_ @Config
+      config <- fromEnv @Config
       config `shouldBe` Nothing
 
     it "returns the configuration object when all necessary variables are set" $ do
       setEnv "dbURL" "hello"
       setEnv "apiKey" "world"
-      config <- fromEnv_
+      config <- fromEnv
       config `shouldSatisfy` isJust
       fromJust config `shouldBe` Config "hello" "world"
 
     it "returns the configuration object when using different names for the environment variables" $ do
       setEnv "DB_URL" "hello"
       setEnv "API_KEY" "world"
-      let converter "dbURL"  = Just "DB_URL"
-          converter "apiKey" = Just "API_KEY"
-          converter _        = Nothing
-      config <- fromEnv converter
+      config <- gFromEnv (defaultEnvOpts { optsFieldLabelModifier = toUpperSnake })
       config `shouldSatisfy` isJust
       fromJust config `shouldBe` Config "hello" "world"
 

--- a/src/Configuration/Dotenv/FromEnv.hs
+++ b/src/Configuration/Dotenv/FromEnv.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DefaultSignatures    #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Configuration.Dotenv.FromEnv (FromEnv (..), fromEnv_) where
+
+import           Control.Applicative              (liftA2)
+import           Control.Monad.IO.Class           (MonadIO, liftIO)
+import           Data.Text                        (Text)
+import qualified Data.Text                        as T
+import           GHC.Generics
+
+import           Configuration.Dotenv.Environment (lookupEnv)
+
+class TrivialParse a where
+  triviallyParse :: String -> Maybe a
+
+instance TrivialParse Int where
+  triviallyParse = Just . read
+
+instance TrivialParse String where
+   triviallyParse = Just
+
+instance TrivialParse Char where
+   triviallyParse [c] = Just c
+   triviallyParse _   = Nothing
+
+instance TrivialParse Text where
+  triviallyParse = Just . T.pack
+
+-- | Convert from a field name to an environment variable name.
+type NameConverter = String -> Maybe String
+
+-- | Class for things that can be created from environment variables.
+class FromEnv a where
+  -- | Try to construct a value from environment variables.
+  fromEnv :: (MonadIO m) => NameConverter -> m (Maybe a)
+  default fromEnv :: (MonadIO m, Generic a, FromEnv' (Rep a)) => NameConverter -> m (Maybe a)
+  fromEnv converter = fmap to <$> fromEnv' converter
+
+-- | Use 'id' as the name converter.
+fromEnv_ :: (FromEnv a, MonadIO m) => m (Maybe a)
+fromEnv_ = fromEnv Just
+
+class FromEnv' f where
+  fromEnv' :: (MonadIO m) => NameConverter -> m (Maybe (f a))
+
+instance {-# OVERLAPPING #-} FromEnv' f => FromEnv' (M1 i c f) where
+  fromEnv' converter = fmap M1 <$> fromEnv' converter
+
+instance (FromEnv' f, FromEnv' g) => FromEnv' (f :*: g)  where
+  fromEnv' converter = do
+    f' <- fromEnv' @f converter
+    g' <- fromEnv' @g converter
+    return $ liftA2 (:*:) f' g'
+
+instance {-# OVERLAPPING #-} (Selector s, TrivialParse a) => FromEnv' (M1 S s (K1 i a)) where
+  fromEnv' converter = do
+    let m :: M1 i s f a
+        m = undefined
+        name = converter $ selName m
+    case name of
+      Just name' -> do
+        c <- liftIO $ lookupEnv name'
+        return $ fmap (M1 . K1) (triviallyParse =<< c)
+      Nothing -> return Nothing


### PR DESCRIPTION
Hi! I added a small class to be able to create values from environment variables, like this:
```haskell
newtype Config = Config { s3Bucket :: String } deriving (Generic, FromEnv)

main = do
    -- This returns m (Maybe Config)
    -- Where m is some MonadIO
    -- Also, we mostly don't need this type application depending on the context
    config <- fromEnv_ @Config
```
I think this would be a nice addition to this library. I am new to generic programming, so I
would highly appreciate any feedback to make this good enough to be included in the library.

Finally, I added some tests and documented the public api in `Configuration.Dotenv.FromEnv`.