### PR TITLE
Added upper limits of required dependencies

### DIFF
--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -91,7 +91,7 @@ library
                        , Configuration.Dotenv.Text
                        , Configuration.Dotenv.Types
 
-  build-depends:         base >= 4.16.4 && < 4.17
+  build-depends:         base >= 4.14
                        , directory >= 1.3.6 && < 1.4
                        , megaparsec >= 9.2.2 && <= 9.4.1
                        , containers >= 0.6.5 && < 1.7

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -97,7 +97,7 @@ library
                        , containers >= 0.6.5 && < 1.7
                        , process >= 1.6.16 && < 1.7
                        , shellwords >= 0.1.3 && < 0.2
-                       , text >= 1.2.5 && < 1.3
+                       , text >= 1.2.0.0 && < 1.3
                        , exceptions >= 0.8 && < 0.11
                        , mtl >= 2.2.2 && < 2.4
                        , data-default-class >= 0.1.2 && < 0.2

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -97,7 +97,7 @@ library
                        , containers >= 0.6.5 && < 1.7
                        , process >= 1.6.16 && < 1.7
                        , shellwords >= 0.1.3 && < 0.2
-                       , text >= 1.2.0.0 && < 1.3
+                       , text >= 1.2.0.0 && < 3.0
                        , exceptions >= 0.8 && < 0.11
                        , mtl >= 2.2.2 && < 2.4
                        , data-default-class >= 0.1.2 && < 0.2

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -66,9 +66,9 @@ executable dotenv
                        , base-compat >= 0.4
                        , dotenv
                        , optparse-applicative >= 0.11 && < 0.19
-                       , megaparsec
-                       , process
-                       , text
+                       , megaparsec >= 9.2.2 && <= 9.4.1
+                       , process >= 1.6.16 && < 1.7
+                       , text >= 1.2.5 && < 1.3
   other-modules: Paths_dotenv
 
   hs-source-dirs:      app
@@ -91,12 +91,12 @@ library
                        , Configuration.Dotenv.Types
 
   build-depends:         base >= 4.9 && < 5.0
-                       , directory
-                       , megaparsec >= 7.0.1 && < 10.0
-                       , containers
+                       , directory >= 1.3.6 && < 1.4
+                       , megaparsec >= 9.2.2 && <= 9.4.1
+                       , containers >= 0.6.5 && < 1.7
                        , process >= 1.6.3.0 && < 1.7
                        , shellwords >= 0.1.3.0
-                       , text
+                       , text >= 1.2.5 && < 1.3
                        , exceptions >= 0.8 && < 0.11
                        , mtl >= 2.2.2 && < 2.4
                        , data-default-class >= 0.1.2 && < 0.2
@@ -119,10 +119,10 @@ test-suite dotenv-test
 
   build-depends:       base >= 4.9 && < 5.0
                      , dotenv
-                     , megaparsec
-                     , hspec
-                     , process
-                     , text
+                     , megaparsec >= 9.2.2 && <= 9.4.1
+                     , hspec >= 2.9.7 && <= 2.11.4
+                     , process >= 1.6.16 && < 1.7
+                     , text >= 1.2.5 && < 1.3
                      , hspec-megaparsec >= 2.0 && < 3.0
 
   build-tools:        hspec-discover   >= 2.0 && < 3.0

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -93,7 +93,7 @@ library
 
   build-depends:         base >= 4.14
                        , directory >= 1.3.6 && < 1.4
-                       , megaparsec >= 9.2.2 && <= 9.4.1
+                       , megaparsec >= 7.0.1 && < 10.0
                        , containers >= 0.6.5 && < 1.7
                        , process >= 1.6.16 && < 1.7
                        , shellwords >= 0.1.3 && < 0.2

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -62,13 +62,13 @@ flag dev
 
 executable dotenv
   main-is:             Main.hs
-  build-depends:         base >= 4.9 && < 5.0
-                       , base-compat >= 0.4
+  build-depends:         base
+                       , base-compat >= 0.4.0
                        , dotenv
                        , optparse-applicative >= 0.11 && < 0.19
-                       , megaparsec >= 9.2.2 && <= 9.4.1
-                       , process >= 1.6.16 && < 1.7
-                       , text >= 1.2.5 && < 1.3
+                       , megaparsec
+                       , process
+                       , text
   other-modules: Paths_dotenv
 
   hs-source-dirs:      app
@@ -90,12 +90,12 @@ library
                        , Configuration.Dotenv.Text
                        , Configuration.Dotenv.Types
 
-  build-depends:         base >= 4.9 && < 5.0
+  build-depends:         base >= 4.16.4 && < 4.17
                        , directory >= 1.3.6 && < 1.4
                        , megaparsec >= 9.2.2 && <= 9.4.1
                        , containers >= 0.6.5 && < 1.7
-                       , process >= 1.6.3.0 && < 1.7
-                       , shellwords >= 0.1.3.0
+                       , process >= 1.6.16 && < 1.7
+                       , shellwords >= 0.1.3 && < 0.2
                        , text >= 1.2.5 && < 1.3
                        , exceptions >= 0.8 && < 0.11
                        , mtl >= 2.2.2 && < 2.4
@@ -117,12 +117,12 @@ test-suite dotenv-test
                        , Configuration.Dotenv.TextSpec
                        , Configuration.Dotenv.ParseSpec
 
-  build-depends:       base >= 4.9 && < 5.0
+  build-depends:       base
                      , dotenv
-                     , megaparsec >= 9.2.2 && <= 9.4.1
+                     , megaparsec
                      , hspec >= 2.9.7 && <= 2.11.4
-                     , process >= 1.6.16 && < 1.7
-                     , text >= 1.2.5 && < 1.3
+                     , process
+                     , text
                      , hspec-megaparsec >= 2.0 && < 3.0
 
   build-tools:        hspec-discover   >= 2.0 && < 3.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,3 @@
 resolver: lts-20.11
+
+  

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,1 @@
 resolver: lts-20.11
-
-  


### PR DESCRIPTION
#174
**Issue 1: 'ghc-options: -O2' is rarely needed:**
Time tests were conducted using `time cabal build`, yielding the following results:
Without using "-O2":
![image](https://github.com/stackbuilders/dotenv-hs/assets/112514991/ee776b29-896e-41c5-8696-a7a0acbab58b)

With the use of "-O2":
![image](https://github.com/stackbuilders/dotenv-hs/assets/112514991/1967a5fd-7207-48fd-b92d-4bab7da2f671)

From these results, we can see that the use of "-O2" doesn't actually provide any time-related benefits.

**Issue 2: Missing Upper Bounds in Dependency Packages**
Upper bounds were added to the dependencies that required them: "-compat -containers -directory -hspec -shellwords -text". The `gen-bounds` tool was used, as suggested. Tests were conducted via `stack` to assess the compatibility of each of the packages with the upper bounds I set, based on the proposed suggestions using the `gen-bounds` tool."