### PR TITLE
Correction when defining the boundaries of each dependency

### DIFF
--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -63,8 +63,8 @@ flag dev
 
 executable dotenv
   main-is:             Main.hs
-  build-depends:         base >= 4.14 && < 5.0
-                       , base-compat >= 0.4
+  build-depends:         base
+                       , base-compat >= 0.4.0
                        , dotenv
                        , optparse-applicative >= 0.11 && < 0.19
                        , megaparsec
@@ -91,13 +91,13 @@ library
                        , Configuration.Dotenv.Text
                        , Configuration.Dotenv.Types
 
-  build-depends:         base >= 4.9 && < 5.0
-                       , directory
-                       , megaparsec >= 7.0.1 && < 10.0
-                       , containers
-                       , process >= 1.6.3.0 && < 1.7
-                       , shellwords >= 0.1.3.0
-                       , text
+  build-depends:         base >= 4.16.4 && < 4.17
+                       , directory >= 1.3.6 && < 1.4
+                       , megaparsec >= 9.2.2 && <= 9.4.1
+                       , containers >= 0.6.5 && < 1.7
+                       , process >= 1.6.16 && < 1.7
+                       , shellwords >= 0.1.3 && < 0.2
+                       , text >= 1.2.5 && < 1.3
                        , exceptions >= 0.8 && < 0.11
                        , mtl >= 2.2.2 && < 2.4
                        , data-default-class >= 0.1.2 && < 0.2
@@ -118,10 +118,10 @@ test-suite dotenv-test
                        , Configuration.Dotenv.TextSpec
                        , Configuration.Dotenv.ParseSpec
 
-  build-depends:       base >= 4.9 && < 5.0
+  build-depends:       base
                      , dotenv
                      , megaparsec
-                     , hspec
+                     , hspec >= 2.9.7 && <= 2.11.4
                      , process
                      , text
                      , hspec-megaparsec >= 2.0 && < 3.0


### PR DESCRIPTION
#174 

In this update, we fixed an issue related to defining version constraints for dependencies across different sections of the .cabal file. Originally, version constraints for certain dependencies were defined in multiple sections, including library, executable, and test-suite. However, following best practices and the project owner's recommendation, these constraints are now defined in a single section, allowing the constraints to be automatically inherited by the other sections. This simplifies the .cabal file and ensures more efficient dependency management.

Specific changes include removing redundant version constraints in the executable and test-suite sections, keeping only the constraints in the library section as the reference point for other sections. This improves the clarity and maintainability of the .cabal file.