### PR TITLE
Added `kleidukos/get-tested` action to generate CI matrix #64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           cabal-file: dotenv.cabal
           ubuntu: true
+          macos: true
           version: 0.1.6.0
 
   build-and-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs: 
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.6.0
+        with:
+          cabal-file: dotenv.cabal
+          ubuntu: true
+          version: 0.1.6.0
+
   build-and-test:
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        ghc: ["8.10", "9.0", "9.2", "9.4", "9.6"]
-        os: [ubuntu-latest]
-        include:
-          - os: macos-latest
-            ghc: "9.2"
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v3

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -34,7 +34,7 @@ description:
 license:             MIT
 license-file:        LICENSE
 author:              Justin Leitgeb
-tested-with:         ghc ==8.10 ghc ==9.0 ghc ==9.2 ghc ==9.4 ghc ==9.6
+tested-with:         GHC==8.10, GHC==9.6, GHC==9.8
 maintainer:          hackage@stackbuilders.com
 copyright:           2015-Present Stack Builders Inc.
 category:            Configuration


### PR DESCRIPTION
Thanks to the [get-tested](https://github.com/Kleidukos/get-tested) action, we can automatically generate the matrix of GHC versions to run the CI on. This keeps the `tested-with` versions we set in Cabal files accurate to what is actually being tested in the CI.

Since the action takes one Cabal file as reference, I pointed it to `rollbar-client.cabal` since that is the main library in this repository. In any case, us maintainers need to keep all of the `tested-with` versions in sync across the four Haskell packages we offer in this repository.

This PR also changes the `tested-with` versions of the Cabal in the project to the latest minor versions of GHC 8.10 (the latest GHC 8 version), GHC 9.6 and GHC 9.8 (the two most recent GHC 9 versions).

Closes #189.