### PR TITLE
Updating CI to new `get-tested` version (v0.1.7.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           cabal-file: dotenv.cabal
           ubuntu-version: latest
-          macos-version: latest
+          macos-version: 14
           version: 0.1.6.0
 
   build-and-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
         uses: kleidukos/get-tested@v0.1.7.0
         with:
           cabal-file: dotenv.cabal
-          ubuntu: true
-          macos: true
+          ubuntu-version: latest
+          macos-version: latest
           version: 0.1.6.0
 
   build-and-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Extract the tested GHC versions
         id: set-matrix
-        uses: kleidukos/get-tested@v0.1.6.0
+        uses: kleidukos/get-tested@v0.1.7.0
         with:
           cabal-file: dotenv.cabal
           ubuntu: true


### PR DESCRIPTION
I opened this issue https://github.com/Kleidukos/get-tested/issues/32 in the `get-tested` repo with a feature request to support setting the specific version of the OS runner we want to run; prior to the v0.1.7.0 version, the runners were all set to `*-latest`. Thanks to @Kleidukos' work, this is now supported in the most recent v0.1.7.0 version of `get-tested`. This PR changes our workflow to this new version of the action.