### PR TITLE
Parse configuration file from current directory for additional flags

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,7 +14,6 @@ import           Paths_dotenv         (version)
 import           Configuration.Dotenv (Config (..), defaultConfig, loadFile)
 import           System.Directory     (doesFileExist)
 import           System.Exit          (exitWith)
-import           System.IO            (readFile')
 import           System.Process       (system)
 
 data Options = Options
@@ -158,7 +157,7 @@ loadFlagsFromConfig = do
     configExists <- doesFileExist configFile
     if not configExists then return defaultFlags
     else do
-        arguments <- words <$> readFile' configFile
+        arguments <- words <$> readFile configFile
         case execParserPure defaultPrefs (mkOpts flagsP) arguments of
             result@(Failure _) -> do
                 putStrLn "There were errors while parsing the configuration file"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,7 +12,9 @@ import           Options.Applicative
 import           Paths_dotenv         (version)
 
 import           Configuration.Dotenv (Config (..), defaultConfig, loadFile)
+import           System.Directory     (doesFileExist)
 import           System.Exit          (exitWith)
+import           System.IO            (readFile')
 import           System.Process       (system)
 
 data Options = Options
@@ -26,9 +28,42 @@ data Options = Options
   , args               :: [String]
   } deriving (Show)
 
+data Flags = Flags
+  { flagDotenvFiles        :: [String]
+  , flagDotenvExampleFiles :: [String]
+  , flagOverride           :: Bool
+  , flagVerbose            :: Bool
+  , flagDryRun             :: Bool
+  , flagDuplicates         :: Bool
+  }
+
+defaultFlags :: Flags
+defaultFlags = Flags
+  { flagDotenvFiles = []
+  , flagDotenvExampleFiles = []
+  , flagOverride = False
+  , flagVerbose = False
+  , flagDryRun = False
+  , flagDuplicates = False
+  }
+
+applyFlags :: Options -> Flags -> Options
+applyFlags options flags = Options
+  { dotenvFiles = dotenvFiles options <> flagDotenvFiles flags
+  , dotenvExampleFiles = dotenvExampleFiles options <> flagDotenvExampleFiles flags
+  , override = override options || flagOverride flags
+  , verbose = verbose options || flagVerbose flags
+  , dryRun = dryRun options || flagDryRun flags
+  , duplicates = duplicates options || flagDuplicates flags
+  , program = program options
+  , args = args options
+  }
+
 main :: IO ()
 main = do
-  Options{..} <- execParser opts
+  options <- execParser $ mkOpts config
+  flags <- loadFlagsFromConfig
+  let Options{..} = applyFlags options flags
   let configDotenv =
         Config
           { configExamplePath = dotenvExampleFiles
@@ -46,45 +81,86 @@ main = do
     if configDryRun configDotenv
       then putStrLn "[INFO]: Dry run mode enabled. Not executing the program."
       else system (program ++ concatMap (" " ++) args) >>= exitWith
-       where
-         opts = info (helper <*> versionOption <*> config)
-           ( fullDesc
-          <> progDesc "Runs PROGRAM after loading options from FILE"
-          <> header "dotenv - loads options from dotenv files" )
-         versionOption =
-           infoOption
+
+mkOpts :: Parser a -> ParserInfo a
+mkOpts p = info (helper <*> versionOption <*> p)
+    ( fullDesc
+    <> progDesc "Runs PROGRAM after loading options from FILE"
+    <> header "dotenv - loads options from dotenv files" )
+    where
+        versionOption = infoOption
              (showVersion version)
              (long "version" <> short 'v' <> help "Show version of the program")
 
 config :: Parser Options
 config = Options
-     <$> many (strOption (
-                  long "dotenv"
-                  <> short 'f'
-                  <> metavar "DOTENV"
-                  <> help "File to read for environmental variables" ))
-
-     <*> many (strOption (
-                  long "example"
-                  <> short 'x'
-                  <> metavar "DOTENV_EXAMPLE"
-                  <> help "File to read for needed environmental variables" ))
-
-     <*> switch ( long "overload"
-                  <> short 'o'
-                  <> help "Specify this flag to override existing variables" )
-
-     <*> switch (  long "verbose"
-                  <> help "Specify this flag to print out the variables loaded and other useful insights" )
-
-     <*> switch (  long "dry-run"
-                  <> help "Specify this flag to print out the variables loaded without executing the program" )
-
-     <*> flag True False (  long "no-dups"
-                  <> short 'D'
-                  <> help "Specify this flag to forbid duplicate variables"
-                  )
-
+     <$> dotenvFileOption
+     <*> exampleFileOption
+     <*> overloadOption
+     <*> verboseOption
+     <*> dryRunOption
+     <*> noDuplicatesOption
      <*> argument str (metavar "PROGRAM")
-
      <*> many (argument str (metavar "ARG"))
+
+dotenvFileOption :: Parser [String]
+dotenvFileOption = many
+    ( strOption (
+        long "dotenv"
+        <> short 'f'
+        <> metavar "DOTENV"
+        <> help "File to read for environmental variables" ))
+
+exampleFileOption :: Parser [FilePath]
+exampleFileOption =  many
+    ( strOption (
+        long "example"
+        <> short 'x'
+        <> metavar "DOTENV_EXAMPLE"
+        <> help "File to read for needed environmental variables" ))
+
+overloadOption :: Parser Bool
+overloadOption = switch
+    ( long "overload"
+    <> short 'o'
+    <> help "Specify this flag to override existing variables" )
+
+verboseOption :: Parser Bool
+verboseOption = switch
+    ( long "verbose"
+    <> help "Specify this flag to print out the variables loaded and other useful insights" )
+
+dryRunOption :: Parser Bool
+dryRunOption = switch
+    (  long "dry-run"
+    <> help "Specify this flag to print out the variables loaded without executing the program" )
+
+noDuplicatesOption :: Parser Bool
+noDuplicatesOption = flag True False
+    ( long "no-dups"
+    <> short 'D'
+    <> help "Specify this flag to forbid duplicate variables" )
+
+flagsP :: Parser Flags
+flagsP = Flags
+     <$> dotenvFileOption
+     <*> exampleFileOption
+     <*> overloadOption
+     <*> verboseOption
+     <*> dryRunOption
+     <*> noDuplicatesOption
+
+configFile :: FilePath
+configFile = "dotenv.config"
+
+loadFlagsFromConfig :: IO Flags
+loadFlagsFromConfig = do
+    configExists <- doesFileExist configFile
+    if not configExists then return defaultFlags
+    else do
+        arguments <- words <$> readFile' configFile
+        case execParserPure defaultPrefs (mkOpts flagsP) arguments of
+            result@(Failure _) -> do
+                putStrLn "There were errors while parsing the configuration file"
+                handleParseResult result
+            result -> handleParseResult result

--- a/dotenv.cabal
+++ b/dotenv.cabal
@@ -70,6 +70,7 @@ executable dotenv
                        , megaparsec
                        , process
                        , text
+                       , directory
   other-modules: Paths_dotenv
 
   hs-source-dirs:      app


### PR DESCRIPTION
This is tackling #160 

I added a separate record `Flags` to hold the flags that can be parsed from a configuration file, tentatively `dotenv.config` in the current directory.

At first, I tried to reuse the `Options` record, but this became messy when dealing with the `program` argument. I could not find a non-hacky way to deal with that and thought that it would be best to have a separate parser for the flags.

Having said that, I extracted the option parsers to separate definitions to reuse as much code as possible and also so that the parsers for flags and options keep in sync.

`applyFlags` takes care of combining the flags from command line arguments and the configuration file. `<>` for list arguments is a natural combination, and I believe `||` for booleans also works correctly.

Some execution examples:

```
# dotenv.config
-x .env.example
-f .env
```

```
# .env.example
API_URL=
```

```
# .env
```

Command:

```
dotenv echo hello
```

Output: 

```
dotenv: The following variables are present in .env.example, but not set in the current environment, or .env: API_URL
CallStack (from HasCallStack):
  error, called at src/Configuration/Dotenv.hs:82:16 in dotenv-0.12.0.0-inplace:Configuration.Dotenv
```

Another example:

```
# dotenv.config
echo hello
```

Command:

```
dotenv echo hello
```

Output:

```
There were errors while parsing the configuration file
Invalid argument `echo'

Usage: dotenv [-v|--version] [-f|--dotenv DOTENV] [-x|--example DOTENV_EXAMPLE] 
              [-o|--overload] [--verbose] [--dry-run] [-D|--no-dups]

  Runs PROGRAM after loading options from FILE
```

I print a special message when errors come from the config file so the user knows where to look.

I might be missing something, what do you think?

Also, I had to add `directory` as a dependency to check for the file existence, but if there is a better way to do this without adding an extra dependency that would be great.